### PR TITLE
fix: Add tool_call_id to Message struct for OpenAI compatibility

### DIFF
--- a/aof/crates/aof-core/src/agent.rs
+++ b/aof/crates/aof-core/src/agent.rs
@@ -59,6 +59,9 @@ pub struct Message {
     pub content: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_calls: Option<Vec<crate::ToolCall>>,
+    /// Tool call ID (required for Tool role messages)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
 }
 
 /// Message role
@@ -114,6 +117,7 @@ impl AgentContext {
             role,
             content: content.into(),
             tool_calls: None,
+            tool_call_id: None,
         });
     }
 

--- a/aof/crates/aof-core/src/model.rs
+++ b/aof/crates/aof-core/src/model.rs
@@ -131,6 +131,9 @@ pub struct RequestMessage {
     pub content: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_calls: Option<Vec<crate::ToolCall>>,
+    /// Tool call ID (required for Tool role messages)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
 }
 
 /// Message role

--- a/aof/crates/aof-llm/src/provider/openai.rs
+++ b/aof/crates/aof-llm/src/provider/openai.rs
@@ -93,7 +93,7 @@ impl OpenAIModel {
                         })
                         .collect()
                 }),
-                tool_call_id: None,
+                tool_call_id: m.tool_call_id.clone(),
             }));
             msgs
         } else {
@@ -123,7 +123,7 @@ impl OpenAIModel {
                             })
                             .collect()
                     }),
-                    tool_call_id: None,
+                    tool_call_id: m.tool_call_id.clone(),
                 })
                 .collect()
         };

--- a/aof/crates/aof-runtime/src/executor/agent_executor.rs
+++ b/aof/crates/aof-runtime/src/executor/agent_executor.rs
@@ -276,6 +276,7 @@ impl AgentExecutor {
                 role: MessageRole::Assistant,
                 content: iteration_content.clone(),
                 tool_calls: None,
+                tool_call_id: None,
             };
 
             if !tool_calls_buffer.is_empty() {
@@ -367,6 +368,7 @@ impl AgentExecutor {
                             content: serde_json::to_string(&result.data)
                                 .unwrap_or_else(|_| "{}".to_string()),
                             tool_calls: None,
+                            tool_call_id: Some(tool_call.id.clone()),
                         };
                         ctx.messages.push(tool_msg);
                     }
@@ -521,6 +523,7 @@ impl AgentExecutor {
                 role: MessageRole::Assistant,
                 content: response.content.clone(),
                 tool_calls: None,
+                tool_call_id: None,
             };
 
             if !response.tool_calls.is_empty() {
@@ -605,6 +608,7 @@ impl AgentExecutor {
                             content: serde_json::to_string(&result.data)
                                 .unwrap_or_else(|_| "{}".to_string()),
                             tool_calls: None,
+                            tool_call_id: Some(tool_call.id.clone()),
                         };
                         context.messages.push(tool_msg);
                     }
@@ -652,6 +656,7 @@ impl AgentExecutor {
                 },
                 content: m.content.clone(),
                 tool_calls: m.tool_calls.clone(),
+                tool_call_id: m.tool_call_id.clone(),
             })
             .collect();
 


### PR DESCRIPTION
## Summary
- Fixed critical bug where OpenAI API tool calling fails on second iteration
- Added `tool_call_id` field to `Message` and `RequestMessage` structs

## Problem
OpenAI API requires messages with role 'tool' to have a 'tool_call_id' field that references the original tool call. Without this, agent tool execution fails with:
```
Missing parameter 'tool_call_id': messages with role 'tool' must have a 'tool_call_id'
```

## Changes
- `aof-core/src/agent.rs` - Added `tool_call_id` field to `Message` struct
- `aof-core/src/model.rs` - Added `tool_call_id` field to `RequestMessage` struct
- `aof-runtime/src/executor/agent_executor.rs` - Updated to pass `tool_call_id` when creating tool messages
- `aof-llm/src/provider/openai.rs` - Updated to pass `tool_call_id` to API

## Test plan
- [x] Build passes: `cargo build --release`
- [x] Tested with OpenAI API: Agent can now successfully execute tools in multi-turn conversations
- [x] Verified tool calling works with `gpt-4o-mini` model

🤖 Generated with [Claude Code](https://claude.com/claude-code)