### PR TITLE
feat: Add unified ToolSpec for built-in and MCP tools

### DIFF
--- a/aof/Cargo.toml
+++ b/aof/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/aof-runtime",
     "crates/aof-memory",
     "crates/aof-triggers",
+    "crates/aof-tools",
     "crates/aofctl",
     "crates/smoke-test-mcp",
     "crates/test-trigger-server",
@@ -73,6 +74,11 @@ aof-llm = { path = "crates/aof-llm" }
 aof-runtime = { path = "crates/aof-runtime" }
 aof-memory = { path = "crates/aof-memory" }
 aof-triggers = { path = "crates/aof-triggers" }
+aof-tools = { path = "crates/aof-tools" }
+
+# File utilities
+glob = "0.3"
+which = "6.0"
 
 [profile.release]
 opt-level = 3

--- a/aof/crates/aof-core/src/fleet.rs
+++ b/aof/crates/aof-core/src/fleet.rs
@@ -110,8 +110,9 @@ pub struct FleetAgentSpec {
     pub instructions: Option<String>,
 
     /// Tools available to this agent
+    /// Supports both simple strings and qualified specs
     #[serde(default)]
-    pub tools: Vec<String>,
+    pub tools: Vec<crate::agent::ToolSpec>,
 
     /// MCP servers for this agent
     #[serde(default)]

--- a/aof/crates/aof-core/src/lib.rs
+++ b/aof/crates/aof-core/src/lib.rs
@@ -16,7 +16,7 @@ pub mod workflow;
 // Re-export core types
 pub use agent::{
     Agent, AgentConfig, AgentContext, AgentMetadata, ExecutionMetadata, Message, MessageRole,
-    ToolResult as AgentToolResult,
+    QualifiedToolSpec, ToolResult as AgentToolResult, ToolSource, ToolSpec,
 };
 pub use error::{AofError, AofResult};
 pub use error_tracker::{ErrorKnowledgeBase, ErrorRecord, ErrorStats};

--- a/aof/crates/aof-tools/Cargo.toml
+++ b/aof/crates/aof-tools/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "aof-tools"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "Modular tool implementations for AOF agents"
+
+[features]
+default = ["file", "shell", "git"]
+file = []
+shell = []
+kubectl = []
+docker = []
+git = []
+terraform = []
+http = ["reqwest"]
+observability = ["reqwest"]
+all = ["file", "shell", "kubectl", "docker", "git", "terraform", "http", "observability"]
+
+[dependencies]
+aof-core = { workspace = true }
+tokio = { workspace = true, features = ["process", "fs", "io-util"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+async-trait = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+glob = { workspace = true }
+reqwest = { workspace = true, optional = true }
+which = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["test-util", "full", "macros"] }
+tempfile = "3"

--- a/aof/crates/aof-tools/src/lib.rs
+++ b/aof/crates/aof-tools/src/lib.rs
@@ -1,0 +1,95 @@
+//! AOF Tools - Modular tool implementations for AOF agents
+//!
+//! This crate provides a collection of built-in tools that agents can use.
+//! Tools are organized by category and can be enabled/disabled via feature flags.
+//!
+//! # Feature Flags
+//!
+//! - `file` - File system operations (read, write, list, search)
+//! - `shell` - Shell command execution
+//! - `kubectl` - Kubernetes operations via kubectl
+//! - `docker` - Docker container operations
+//! - `git` - Git repository operations
+//! - `terraform` - Terraform IaC operations
+//! - `http` - HTTP request tool
+//! - `all` - Enable all tools
+//!
+//! # Architecture
+//!
+//! Tools can be used in two ways:
+//! 1. **Built-in tools**: Direct Rust implementations (this crate)
+//! 2. **MCP tools**: External MCP servers for the same functionality
+//!
+//! Users can choose their preferred approach based on requirements:
+//! - Built-in: Lower latency, no external dependencies
+//! - MCP: More flexible, can use community servers
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use aof_tools::{ToolRegistry, FileTools, ShellTool};
+//!
+//! let mut registry = ToolRegistry::new();
+//! registry.register_category(FileTools::all());
+//! registry.register(ShellTool::new());
+//!
+//! // Use with agent
+//! let executor = registry.into_executor();
+//! ```
+
+pub mod registry;
+pub mod tools;
+
+pub use registry::{ToolRegistry, BuiltinToolExecutor};
+
+// Re-export individual tools based on features
+#[cfg(feature = "file")]
+pub use tools::file::{FileTools, ReadFileTool, WriteFileTool, ListDirTool, SearchFilesTool};
+
+#[cfg(feature = "shell")]
+pub use tools::shell::ShellTool;
+
+#[cfg(feature = "kubectl")]
+pub use tools::kubectl::{KubectlTools, KubectlGetTool, KubectlApplyTool, KubectlDeleteTool, KubectlLogsTool, KubectlExecTool, KubectlDescribeTool};
+
+#[cfg(feature = "docker")]
+pub use tools::docker::{DockerTools, DockerPsTool, DockerBuildTool, DockerRunTool, DockerLogsTool, DockerExecTool, DockerImagesTool};
+
+#[cfg(feature = "git")]
+pub use tools::git::{GitTools, GitStatusTool, GitDiffTool, GitLogTool, GitCommitTool, GitBranchTool, GitCheckoutTool, GitPullTool, GitPushTool};
+
+#[cfg(feature = "terraform")]
+pub use tools::terraform::{TerraformTools, TerraformInitTool, TerraformPlanTool, TerraformApplyTool, TerraformDestroyTool, TerraformOutputTool};
+
+#[cfg(feature = "http")]
+pub use tools::http::HttpTool;
+
+#[cfg(feature = "observability")]
+pub use tools::observability::{ObservabilityTools, PrometheusQueryTool, LokiQueryTool, ElasticsearchQueryTool, VictoriaMetricsQueryTool};
+
+/// Prelude module for convenient imports
+pub mod prelude {
+    pub use super::registry::{ToolRegistry, BuiltinToolExecutor};
+    pub use aof_core::{Tool, ToolExecutor, ToolInput, ToolResult, ToolConfig, ToolDefinition};
+
+    #[cfg(feature = "file")]
+    pub use super::tools::file::FileTools;
+
+    #[cfg(feature = "shell")]
+    pub use super::tools::shell::ShellTool;
+
+    #[cfg(feature = "kubectl")]
+    pub use super::tools::kubectl::KubectlTools;
+
+    #[cfg(feature = "docker")]
+    pub use super::tools::docker::DockerTools;
+
+    #[cfg(feature = "git")]
+    pub use super::tools::git::GitTools;
+
+    #[cfg(feature = "terraform")]
+    pub use super::tools::terraform::TerraformTools;
+
+    #[cfg(feature = "observability")]
+    pub use super::tools::observability::ObservabilityTools;
+}

--- a/aof/crates/aof-tools/src/registry.rs
+++ b/aof/crates/aof-tools/src/registry.rs
@@ -1,0 +1,388 @@
+//! Tool Registry - Central registration and discovery for tools
+//!
+//! The registry provides a way to organize, discover, and execute tools.
+//! It supports both individual tool registration and bulk category registration.
+
+use aof_core::{AofError, AofResult, Tool, ToolDefinition, ToolExecutor, ToolInput, ToolResult};
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tracing::{debug, info, warn};
+
+/// Tool category for organization
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ToolCategory {
+    /// File system operations
+    File,
+    /// Shell command execution
+    Shell,
+    /// Kubernetes operations
+    Kubectl,
+    /// Docker container operations
+    Docker,
+    /// Git repository operations
+    Git,
+    /// Terraform IaC operations
+    Terraform,
+    /// HTTP request operations
+    Http,
+    /// Custom user-defined tools
+    Custom(String),
+}
+
+impl std::fmt::Display for ToolCategory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ToolCategory::File => write!(f, "file"),
+            ToolCategory::Shell => write!(f, "shell"),
+            ToolCategory::Kubectl => write!(f, "kubectl"),
+            ToolCategory::Docker => write!(f, "docker"),
+            ToolCategory::Git => write!(f, "git"),
+            ToolCategory::Terraform => write!(f, "terraform"),
+            ToolCategory::Http => write!(f, "http"),
+            ToolCategory::Custom(name) => write!(f, "custom:{}", name),
+        }
+    }
+}
+
+/// Tool registry for managing available tools
+#[derive(Default)]
+pub struct ToolRegistry {
+    tools: HashMap<String, Arc<dyn Tool>>,
+    categories: HashMap<ToolCategory, Vec<String>>,
+}
+
+impl ToolRegistry {
+    /// Create a new empty registry
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create a registry with all default tools enabled
+    #[cfg(feature = "all")]
+    pub fn with_all_defaults() -> Self {
+        let mut registry = Self::new();
+
+        #[cfg(feature = "file")]
+        registry.register_category(crate::tools::file::FileTools::all());
+
+        #[cfg(feature = "shell")]
+        registry.register(crate::tools::shell::ShellTool::new());
+
+        #[cfg(feature = "kubectl")]
+        registry.register_category(crate::tools::kubectl::KubectlTools::all());
+
+        #[cfg(feature = "docker")]
+        registry.register_category(crate::tools::docker::DockerTools::all());
+
+        #[cfg(feature = "git")]
+        registry.register_category(crate::tools::git::GitTools::all());
+
+        #[cfg(feature = "terraform")]
+        registry.register_category(crate::tools::terraform::TerraformTools::all());
+
+        registry
+    }
+
+    /// Register a single tool
+    pub fn register<T: Tool + 'static>(&mut self, tool: T) -> &mut Self {
+        let name = tool.config().name.clone();
+        info!(tool = %name, "Registering tool");
+        self.tools.insert(name, Arc::new(tool));
+        self
+    }
+
+    /// Register a tool with a specific category
+    pub fn register_with_category<T: Tool + 'static>(
+        &mut self,
+        tool: T,
+        category: ToolCategory,
+    ) -> &mut Self {
+        let name = tool.config().name.clone();
+        self.tools.insert(name.clone(), Arc::new(tool));
+        self.categories
+            .entry(category)
+            .or_default()
+            .push(name);
+        self
+    }
+
+    /// Register multiple tools from a category
+    pub fn register_category(&mut self, tools: Vec<Box<dyn Tool>>) -> &mut Self {
+        for tool in tools {
+            let name = tool.config().name.clone();
+            self.tools.insert(name, Arc::from(tool));
+        }
+        self
+    }
+
+    /// Register tools with category tracking
+    pub fn register_category_with_name(
+        &mut self,
+        category: ToolCategory,
+        tools: Vec<Box<dyn Tool>>,
+    ) -> &mut Self {
+        for tool in tools {
+            let name = tool.config().name.clone();
+            self.categories
+                .entry(category.clone())
+                .or_default()
+                .push(name.clone());
+            self.tools.insert(name, Arc::from(tool));
+        }
+        self
+    }
+
+    /// Get a tool by name
+    pub fn get(&self, name: &str) -> Option<Arc<dyn Tool>> {
+        self.tools.get(name).cloned()
+    }
+
+    /// List all tool names
+    pub fn list_names(&self) -> Vec<String> {
+        self.tools.keys().cloned().collect()
+    }
+
+    /// List tool definitions
+    pub fn list_definitions(&self) -> Vec<ToolDefinition> {
+        self.tools.values().map(|t| t.definition()).collect()
+    }
+
+    /// List tools by category
+    pub fn list_by_category(&self, category: &ToolCategory) -> Vec<Arc<dyn Tool>> {
+        self.categories
+            .get(category)
+            .map(|names| {
+                names
+                    .iter()
+                    .filter_map(|n| self.tools.get(n).cloned())
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// Get tool count
+    pub fn len(&self) -> usize {
+        self.tools.len()
+    }
+
+    /// Check if registry is empty
+    pub fn is_empty(&self) -> bool {
+        self.tools.is_empty()
+    }
+
+    /// Convert registry into a tool executor
+    pub fn into_executor(self) -> BuiltinToolExecutor {
+        BuiltinToolExecutor::new(self)
+    }
+
+    /// Create executor reference without consuming registry
+    pub fn as_executor(&self) -> BuiltinToolExecutor {
+        BuiltinToolExecutor {
+            tools: self.tools.clone(),
+        }
+    }
+}
+
+/// Built-in tool executor that wraps the registry
+pub struct BuiltinToolExecutor {
+    tools: HashMap<String, Arc<dyn Tool>>,
+}
+
+impl BuiltinToolExecutor {
+    /// Create from registry
+    pub fn new(registry: ToolRegistry) -> Self {
+        Self {
+            tools: registry.tools,
+        }
+    }
+
+    /// Create from a list of tools
+    pub fn from_tools(tools: Vec<Box<dyn Tool>>) -> Self {
+        let mut map = HashMap::new();
+        for tool in tools {
+            let name = tool.config().name.clone();
+            map.insert(name, Arc::from(tool));
+        }
+        Self { tools: map }
+    }
+}
+
+#[async_trait]
+impl ToolExecutor for BuiltinToolExecutor {
+    async fn execute_tool(&self, name: &str, input: ToolInput) -> AofResult<ToolResult> {
+        let tool = self.tools.get(name).ok_or_else(|| {
+            AofError::tool(format!("Tool not found: {}", name))
+        })?;
+
+        debug!(tool = %name, "Executing built-in tool");
+        let start = std::time::Instant::now();
+
+        match tool.execute(input).await {
+            Ok(result) => {
+                let elapsed = start.elapsed().as_millis() as u64;
+                debug!(tool = %name, elapsed_ms = %elapsed, success = %result.success, "Tool execution complete");
+                Ok(result.with_execution_time(elapsed))
+            }
+            Err(e) => {
+                warn!(tool = %name, error = %e, "Tool execution failed");
+                Err(e)
+            }
+        }
+    }
+
+    fn list_tools(&self) -> Vec<ToolDefinition> {
+        self.tools.values().map(|t| t.definition()).collect()
+    }
+
+    fn get_tool(&self, name: &str) -> Option<Arc<dyn Tool>> {
+        self.tools.get(name).cloned()
+    }
+}
+
+/// Composite executor that combines multiple executors
+/// Useful for combining built-in tools with MCP tools
+pub struct CompositeToolExecutor {
+    executors: Vec<Box<dyn ToolExecutor>>,
+}
+
+impl CompositeToolExecutor {
+    /// Create new composite executor
+    pub fn new() -> Self {
+        Self { executors: vec![] }
+    }
+
+    /// Add an executor
+    pub fn add_executor<E: ToolExecutor + 'static>(mut self, executor: E) -> Self {
+        self.executors.push(Box::new(executor));
+        self
+    }
+
+    /// Add a boxed executor
+    pub fn add_boxed(mut self, executor: Box<dyn ToolExecutor>) -> Self {
+        self.executors.push(executor);
+        self
+    }
+}
+
+impl Default for CompositeToolExecutor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ToolExecutor for CompositeToolExecutor {
+    async fn execute_tool(&self, name: &str, input: ToolInput) -> AofResult<ToolResult> {
+        // Try each executor until one can handle the tool
+        for executor in &self.executors {
+            if executor.get_tool(name).is_some() {
+                return executor.execute_tool(name, input).await;
+            }
+        }
+        Err(AofError::tool(format!("Tool not found in any executor: {}", name)))
+    }
+
+    fn list_tools(&self) -> Vec<ToolDefinition> {
+        let mut tools = Vec::new();
+        let mut seen = std::collections::HashSet::new();
+
+        for executor in &self.executors {
+            for tool in executor.list_tools() {
+                if seen.insert(tool.name.clone()) {
+                    tools.push(tool);
+                }
+            }
+        }
+        tools
+    }
+
+    fn get_tool(&self, name: &str) -> Option<Arc<dyn Tool>> {
+        for executor in &self.executors {
+            if let Some(tool) = executor.get_tool(name) {
+                return Some(tool);
+            }
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aof_core::ToolConfig;
+
+    struct MockTool {
+        config: ToolConfig,
+    }
+
+    impl MockTool {
+        fn new(name: &str) -> Self {
+            Self {
+                config: ToolConfig {
+                    name: name.to_string(),
+                    description: format!("Mock tool: {}", name),
+                    parameters: serde_json::json!({}),
+                    tool_type: aof_core::ToolType::Custom,
+                    timeout_secs: 30,
+                    extra: HashMap::new(),
+                },
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Tool for MockTool {
+        async fn execute(&self, _input: ToolInput) -> AofResult<ToolResult> {
+            Ok(ToolResult::success(serde_json::json!({"mock": true})))
+        }
+
+        fn config(&self) -> &ToolConfig {
+            &self.config
+        }
+    }
+
+    #[test]
+    fn test_registry_register() {
+        let mut registry = ToolRegistry::new();
+        registry.register(MockTool::new("test_tool"));
+
+        assert_eq!(registry.len(), 1);
+        assert!(registry.get("test_tool").is_some());
+        assert!(registry.get("nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_registry_list_names() {
+        let mut registry = ToolRegistry::new();
+        registry.register(MockTool::new("tool1"));
+        registry.register(MockTool::new("tool2"));
+
+        let names = registry.list_names();
+        assert_eq!(names.len(), 2);
+        assert!(names.contains(&"tool1".to_string()));
+        assert!(names.contains(&"tool2".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_executor_execute() {
+        let mut registry = ToolRegistry::new();
+        registry.register(MockTool::new("test_tool"));
+
+        let executor = registry.into_executor();
+        let input = ToolInput::new(serde_json::json!({}));
+
+        let result = executor.execute_tool("test_tool", input).await.unwrap();
+        assert!(result.success);
+    }
+
+    #[tokio::test]
+    async fn test_executor_tool_not_found() {
+        let registry = ToolRegistry::new();
+        let executor = registry.into_executor();
+        let input = ToolInput::new(serde_json::json!({}));
+
+        let result = executor.execute_tool("nonexistent", input).await;
+        assert!(result.is_err());
+    }
+}

--- a/aof/crates/aof-tools/src/tools/aws.rs
+++ b/aof/crates/aof-tools/src/tools/aws.rs
@@ -1,0 +1,878 @@
+//! AWS CLI Tools
+//!
+//! Tools for AWS operations via AWS CLI.
+//!
+//! ## Available Tools
+//!
+//! - `aws_s3` - S3 operations (ls, cp, sync, rm)
+//! - `aws_ec2` - EC2 operations (describe-instances, start, stop)
+//! - `aws_logs` - CloudWatch Logs queries
+//! - `aws_iam` - IAM operations
+//! - `aws_lambda` - Lambda operations
+//! - `aws_ecs` - ECS operations
+//!
+//! ## Prerequisites
+//!
+//! - AWS CLI v2 must be installed
+//! - Valid AWS credentials configured (aws configure or env vars)
+//!
+//! ## MCP Alternative
+//!
+//! Use AWS-specific MCP servers for advanced operations.
+
+use aof_core::{AofResult, Tool, ToolConfig, ToolInput, ToolResult};
+use async_trait::async_trait;
+use tracing::debug;
+
+use super::common::{execute_command, create_schema, tool_config_with_timeout};
+
+/// Collection of all AWS tools
+pub struct AwsTools;
+
+impl AwsTools {
+    /// Get all AWS tools
+    pub fn all() -> Vec<Box<dyn Tool>> {
+        vec![
+            Box::new(AwsS3Tool::new()),
+            Box::new(AwsEc2Tool::new()),
+            Box::new(AwsLogsTool::new()),
+            Box::new(AwsIamTool::new()),
+            Box::new(AwsLambdaTool::new()),
+            Box::new(AwsEcsTool::new()),
+        ]
+    }
+
+    /// Check if AWS CLI is available
+    pub fn is_available() -> bool {
+        which::which("aws").is_ok()
+    }
+}
+
+// ============================================================================
+// AWS S3 Tool
+// ============================================================================
+
+/// S3 operations
+pub struct AwsS3Tool {
+    config: ToolConfig,
+}
+
+impl AwsS3Tool {
+    pub fn new() -> Self {
+        let parameters = create_schema(
+            serde_json::json!({
+                "command": {
+                    "type": "string",
+                    "description": "S3 subcommand: ls, cp, sync, rm, mb, rb",
+                    "enum": ["ls", "cp", "sync", "rm", "mb", "rb", "mv"]
+                },
+                "source": {
+                    "type": "string",
+                    "description": "Source path (local or s3://bucket/key)"
+                },
+                "destination": {
+                    "type": "string",
+                    "description": "Destination path (for cp, sync, mv)"
+                },
+                "recursive": {
+                    "type": "boolean",
+                    "description": "Recursive operation",
+                    "default": false
+                },
+                "region": {
+                    "type": "string",
+                    "description": "AWS region"
+                },
+                "profile": {
+                    "type": "string",
+                    "description": "AWS profile name"
+                }
+            }),
+            vec!["command"],
+        );
+
+        Self {
+            config: tool_config_with_timeout(
+                "aws_s3",
+                "AWS S3 operations: list, copy, sync, and manage objects/buckets.",
+                parameters,
+                300,
+            ),
+        }
+    }
+}
+
+impl Default for AwsS3Tool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for AwsS3Tool {
+    async fn execute(&self, input: ToolInput) -> AofResult<ToolResult> {
+        let command: String = input.get_arg("command")?;
+        let source: Option<String> = input.get_arg("source").ok();
+        let destination: Option<String> = input.get_arg("destination").ok();
+        let recursive: bool = input.get_arg("recursive").unwrap_or(false);
+        let region: Option<String> = input.get_arg("region").ok();
+        let profile: Option<String> = input.get_arg("profile").ok();
+
+        let mut args = vec!["s3".to_string(), command.clone()];
+
+        if let Some(ref src) = source {
+            args.push(src.clone());
+        }
+
+        if let Some(ref dest) = destination {
+            args.push(dest.clone());
+        }
+
+        if recursive {
+            args.push("--recursive".to_string());
+        }
+
+        if let Some(ref r) = region {
+            args.push("--region".to_string());
+            args.push(r.clone());
+        }
+
+        if let Some(ref p) = profile {
+            args.push("--profile".to_string());
+            args.push(p.clone());
+        }
+
+        debug!(args = ?args, "Executing aws s3");
+
+        let args_str: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        let result = execute_command("aws", &args_str, None, 300).await;
+
+        match result {
+            Ok(output) => {
+                if output.success {
+                    Ok(ToolResult::success(serde_json::json!({
+                        "output": output.stdout,
+                        "command": command
+                    })))
+                } else {
+                    Ok(ToolResult::error(format!(
+                        "aws s3 {} failed: {}",
+                        command, output.stderr
+                    )))
+                }
+            }
+            Err(e) => Ok(ToolResult::error(e)),
+        }
+    }
+
+    fn config(&self) -> &ToolConfig {
+        &self.config
+    }
+}
+
+// ============================================================================
+// AWS EC2 Tool
+// ============================================================================
+
+/// EC2 operations
+pub struct AwsEc2Tool {
+    config: ToolConfig,
+}
+
+impl AwsEc2Tool {
+    pub fn new() -> Self {
+        let parameters = create_schema(
+            serde_json::json!({
+                "command": {
+                    "type": "string",
+                    "description": "EC2 subcommand",
+                    "enum": [
+                        "describe-instances", "start-instances", "stop-instances",
+                        "reboot-instances", "terminate-instances", "describe-security-groups",
+                        "describe-vpcs", "describe-subnets"
+                    ]
+                },
+                "instance_ids": {
+                    "type": "array",
+                    "description": "Instance IDs for operations",
+                    "items": { "type": "string" }
+                },
+                "filters": {
+                    "type": "array",
+                    "description": "Filters (e.g., Name=tag:Name,Values=prod-*)",
+                    "items": { "type": "string" }
+                },
+                "region": {
+                    "type": "string",
+                    "description": "AWS region"
+                },
+                "profile": {
+                    "type": "string",
+                    "description": "AWS profile name"
+                },
+                "output": {
+                    "type": "string",
+                    "description": "Output format",
+                    "enum": ["json", "text", "table"],
+                    "default": "json"
+                }
+            }),
+            vec!["command"],
+        );
+
+        Self {
+            config: tool_config_with_timeout(
+                "aws_ec2",
+                "AWS EC2 operations: describe, start, stop, and manage instances.",
+                parameters,
+                120,
+            ),
+        }
+    }
+}
+
+impl Default for AwsEc2Tool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for AwsEc2Tool {
+    async fn execute(&self, input: ToolInput) -> AofResult<ToolResult> {
+        let command: String = input.get_arg("command")?;
+        let instance_ids: Vec<String> = input.get_arg("instance_ids").unwrap_or_default();
+        let filters: Vec<String> = input.get_arg("filters").unwrap_or_default();
+        let region: Option<String> = input.get_arg("region").ok();
+        let profile: Option<String> = input.get_arg("profile").ok();
+        let output_format: String = input.get_arg("output").unwrap_or_else(|_| "json".to_string());
+
+        let mut args = vec!["ec2".to_string(), command.clone()];
+
+        if !instance_ids.is_empty() {
+            args.push("--instance-ids".to_string());
+            args.extend(instance_ids);
+        }
+
+        for filter in &filters {
+            args.push("--filters".to_string());
+            args.push(filter.clone());
+        }
+
+        if let Some(ref r) = region {
+            args.push("--region".to_string());
+            args.push(r.clone());
+        }
+
+        if let Some(ref p) = profile {
+            args.push("--profile".to_string());
+            args.push(p.clone());
+        }
+
+        args.push("--output".to_string());
+        args.push(output_format.clone());
+
+        debug!(args = ?args, "Executing aws ec2");
+
+        let args_str: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        let result = execute_command("aws", &args_str, None, 120).await;
+
+        match result {
+            Ok(output) => {
+                if output.success {
+                    let data = if output_format == "json" {
+                        serde_json::from_str(&output.stdout).unwrap_or_else(|_| {
+                            serde_json::json!({ "raw": output.stdout })
+                        })
+                    } else {
+                        serde_json::json!({ "output": output.stdout })
+                    };
+
+                    Ok(ToolResult::success(serde_json::json!({
+                        "data": data,
+                        "command": command
+                    })))
+                } else {
+                    Ok(ToolResult::error(format!(
+                        "aws ec2 {} failed: {}",
+                        command, output.stderr
+                    )))
+                }
+            }
+            Err(e) => Ok(ToolResult::error(e)),
+        }
+    }
+
+    fn config(&self) -> &ToolConfig {
+        &self.config
+    }
+}
+
+// ============================================================================
+// AWS CloudWatch Logs Tool
+// ============================================================================
+
+/// CloudWatch Logs operations
+pub struct AwsLogsTool {
+    config: ToolConfig,
+}
+
+impl AwsLogsTool {
+    pub fn new() -> Self {
+        let parameters = create_schema(
+            serde_json::json!({
+                "command": {
+                    "type": "string",
+                    "description": "Logs subcommand",
+                    "enum": [
+                        "describe-log-groups", "describe-log-streams",
+                        "filter-log-events", "get-log-events", "tail"
+                    ]
+                },
+                "log_group_name": {
+                    "type": "string",
+                    "description": "Log group name"
+                },
+                "log_stream_name": {
+                    "type": "string",
+                    "description": "Log stream name"
+                },
+                "filter_pattern": {
+                    "type": "string",
+                    "description": "Filter pattern for log events"
+                },
+                "start_time": {
+                    "type": "string",
+                    "description": "Start time (Unix timestamp in ms)"
+                },
+                "end_time": {
+                    "type": "string",
+                    "description": "End time (Unix timestamp in ms)"
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum number of events",
+                    "default": 100
+                },
+                "region": {
+                    "type": "string",
+                    "description": "AWS region"
+                },
+                "profile": {
+                    "type": "string",
+                    "description": "AWS profile name"
+                }
+            }),
+            vec!["command"],
+        );
+
+        Self {
+            config: tool_config_with_timeout(
+                "aws_logs",
+                "AWS CloudWatch Logs: query and retrieve log events.",
+                parameters,
+                120,
+            ),
+        }
+    }
+}
+
+impl Default for AwsLogsTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for AwsLogsTool {
+    async fn execute(&self, input: ToolInput) -> AofResult<ToolResult> {
+        let command: String = input.get_arg("command")?;
+        let log_group_name: Option<String> = input.get_arg("log_group_name").ok();
+        let log_stream_name: Option<String> = input.get_arg("log_stream_name").ok();
+        let filter_pattern: Option<String> = input.get_arg("filter_pattern").ok();
+        let start_time: Option<String> = input.get_arg("start_time").ok();
+        let end_time: Option<String> = input.get_arg("end_time").ok();
+        let limit: i32 = input.get_arg("limit").unwrap_or(100);
+        let region: Option<String> = input.get_arg("region").ok();
+        let profile: Option<String> = input.get_arg("profile").ok();
+
+        let mut args = vec!["logs".to_string(), command.clone()];
+
+        if let Some(ref lg) = log_group_name {
+            args.push("--log-group-name".to_string());
+            args.push(lg.clone());
+        }
+
+        if let Some(ref ls) = log_stream_name {
+            args.push("--log-stream-name".to_string());
+            args.push(ls.clone());
+        }
+
+        if let Some(ref fp) = filter_pattern {
+            args.push("--filter-pattern".to_string());
+            args.push(fp.clone());
+        }
+
+        if let Some(ref st) = start_time {
+            args.push("--start-time".to_string());
+            args.push(st.clone());
+        }
+
+        if let Some(ref et) = end_time {
+            args.push("--end-time".to_string());
+            args.push(et.clone());
+        }
+
+        if command == "filter-log-events" || command == "get-log-events" {
+            args.push("--limit".to_string());
+            args.push(limit.to_string());
+        }
+
+        if let Some(ref r) = region {
+            args.push("--region".to_string());
+            args.push(r.clone());
+        }
+
+        if let Some(ref p) = profile {
+            args.push("--profile".to_string());
+            args.push(p.clone());
+        }
+
+        args.push("--output".to_string());
+        args.push("json".to_string());
+
+        debug!(args = ?args, "Executing aws logs");
+
+        let args_str: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        let result = execute_command("aws", &args_str, None, 120).await;
+
+        match result {
+            Ok(output) => {
+                if output.success {
+                    let data = serde_json::from_str(&output.stdout).unwrap_or_else(|_| {
+                        serde_json::json!({ "raw": output.stdout })
+                    });
+
+                    Ok(ToolResult::success(serde_json::json!({
+                        "data": data,
+                        "command": command
+                    })))
+                } else {
+                    Ok(ToolResult::error(format!(
+                        "aws logs {} failed: {}",
+                        command, output.stderr
+                    )))
+                }
+            }
+            Err(e) => Ok(ToolResult::error(e)),
+        }
+    }
+
+    fn config(&self) -> &ToolConfig {
+        &self.config
+    }
+}
+
+// ============================================================================
+// AWS IAM Tool
+// ============================================================================
+
+/// IAM operations
+pub struct AwsIamTool {
+    config: ToolConfig,
+}
+
+impl AwsIamTool {
+    pub fn new() -> Self {
+        let parameters = create_schema(
+            serde_json::json!({
+                "command": {
+                    "type": "string",
+                    "description": "IAM subcommand",
+                    "enum": [
+                        "list-users", "list-roles", "list-policies",
+                        "get-user", "get-role", "get-policy",
+                        "list-attached-role-policies", "list-attached-user-policies"
+                    ]
+                },
+                "user_name": {
+                    "type": "string",
+                    "description": "IAM user name"
+                },
+                "role_name": {
+                    "type": "string",
+                    "description": "IAM role name"
+                },
+                "policy_arn": {
+                    "type": "string",
+                    "description": "Policy ARN"
+                },
+                "profile": {
+                    "type": "string",
+                    "description": "AWS profile name"
+                }
+            }),
+            vec!["command"],
+        );
+
+        Self {
+            config: tool_config_with_timeout(
+                "aws_iam",
+                "AWS IAM: list and describe users, roles, and policies.",
+                parameters,
+                60,
+            ),
+        }
+    }
+}
+
+impl Default for AwsIamTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for AwsIamTool {
+    async fn execute(&self, input: ToolInput) -> AofResult<ToolResult> {
+        let command: String = input.get_arg("command")?;
+        let user_name: Option<String> = input.get_arg("user_name").ok();
+        let role_name: Option<String> = input.get_arg("role_name").ok();
+        let policy_arn: Option<String> = input.get_arg("policy_arn").ok();
+        let profile: Option<String> = input.get_arg("profile").ok();
+
+        let mut args = vec!["iam".to_string(), command.clone()];
+
+        if let Some(ref u) = user_name {
+            args.push("--user-name".to_string());
+            args.push(u.clone());
+        }
+
+        if let Some(ref r) = role_name {
+            args.push("--role-name".to_string());
+            args.push(r.clone());
+        }
+
+        if let Some(ref p) = policy_arn {
+            args.push("--policy-arn".to_string());
+            args.push(p.clone());
+        }
+
+        if let Some(ref pr) = profile {
+            args.push("--profile".to_string());
+            args.push(pr.clone());
+        }
+
+        args.push("--output".to_string());
+        args.push("json".to_string());
+
+        debug!(args = ?args, "Executing aws iam");
+
+        let args_str: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        let result = execute_command("aws", &args_str, None, 60).await;
+
+        match result {
+            Ok(output) => {
+                if output.success {
+                    let data = serde_json::from_str(&output.stdout).unwrap_or_else(|_| {
+                        serde_json::json!({ "raw": output.stdout })
+                    });
+
+                    Ok(ToolResult::success(serde_json::json!({
+                        "data": data,
+                        "command": command
+                    })))
+                } else {
+                    Ok(ToolResult::error(format!(
+                        "aws iam {} failed: {}",
+                        command, output.stderr
+                    )))
+                }
+            }
+            Err(e) => Ok(ToolResult::error(e)),
+        }
+    }
+
+    fn config(&self) -> &ToolConfig {
+        &self.config
+    }
+}
+
+// ============================================================================
+// AWS Lambda Tool
+// ============================================================================
+
+/// Lambda operations
+pub struct AwsLambdaTool {
+    config: ToolConfig,
+}
+
+impl AwsLambdaTool {
+    pub fn new() -> Self {
+        let parameters = create_schema(
+            serde_json::json!({
+                "command": {
+                    "type": "string",
+                    "description": "Lambda subcommand",
+                    "enum": [
+                        "list-functions", "get-function", "invoke",
+                        "list-versions-by-function", "get-function-configuration"
+                    ]
+                },
+                "function_name": {
+                    "type": "string",
+                    "description": "Lambda function name or ARN"
+                },
+                "payload": {
+                    "type": "string",
+                    "description": "JSON payload for invoke"
+                },
+                "region": {
+                    "type": "string",
+                    "description": "AWS region"
+                },
+                "profile": {
+                    "type": "string",
+                    "description": "AWS profile name"
+                }
+            }),
+            vec!["command"],
+        );
+
+        Self {
+            config: tool_config_with_timeout(
+                "aws_lambda",
+                "AWS Lambda: list, describe, and invoke functions.",
+                parameters,
+                120,
+            ),
+        }
+    }
+}
+
+impl Default for AwsLambdaTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for AwsLambdaTool {
+    async fn execute(&self, input: ToolInput) -> AofResult<ToolResult> {
+        let command: String = input.get_arg("command")?;
+        let function_name: Option<String> = input.get_arg("function_name").ok();
+        let payload: Option<String> = input.get_arg("payload").ok();
+        let region: Option<String> = input.get_arg("region").ok();
+        let profile: Option<String> = input.get_arg("profile").ok();
+
+        let mut args = vec!["lambda".to_string(), command.clone()];
+
+        if let Some(ref fn_name) = function_name {
+            args.push("--function-name".to_string());
+            args.push(fn_name.clone());
+        }
+
+        if command == "invoke" {
+            if let Some(ref p) = payload {
+                args.push("--payload".to_string());
+                args.push(p.clone());
+            }
+            args.push("/dev/stdout".to_string()); // Output file for invoke
+        }
+
+        if let Some(ref r) = region {
+            args.push("--region".to_string());
+            args.push(r.clone());
+        }
+
+        if let Some(ref pr) = profile {
+            args.push("--profile".to_string());
+            args.push(pr.clone());
+        }
+
+        if command != "invoke" {
+            args.push("--output".to_string());
+            args.push("json".to_string());
+        }
+
+        debug!(args = ?args, "Executing aws lambda");
+
+        let args_str: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        let result = execute_command("aws", &args_str, None, 120).await;
+
+        match result {
+            Ok(output) => {
+                if output.success {
+                    let data = serde_json::from_str(&output.stdout).unwrap_or_else(|_| {
+                        serde_json::json!({ "raw": output.stdout })
+                    });
+
+                    Ok(ToolResult::success(serde_json::json!({
+                        "data": data,
+                        "command": command
+                    })))
+                } else {
+                    Ok(ToolResult::error(format!(
+                        "aws lambda {} failed: {}",
+                        command, output.stderr
+                    )))
+                }
+            }
+            Err(e) => Ok(ToolResult::error(e)),
+        }
+    }
+
+    fn config(&self) -> &ToolConfig {
+        &self.config
+    }
+}
+
+// ============================================================================
+// AWS ECS Tool
+// ============================================================================
+
+/// ECS operations
+pub struct AwsEcsTool {
+    config: ToolConfig,
+}
+
+impl AwsEcsTool {
+    pub fn new() -> Self {
+        let parameters = create_schema(
+            serde_json::json!({
+                "command": {
+                    "type": "string",
+                    "description": "ECS subcommand",
+                    "enum": [
+                        "list-clusters", "list-services", "list-tasks",
+                        "describe-clusters", "describe-services", "describe-tasks",
+                        "update-service", "stop-task"
+                    ]
+                },
+                "cluster": {
+                    "type": "string",
+                    "description": "ECS cluster name or ARN"
+                },
+                "service": {
+                    "type": "string",
+                    "description": "ECS service name"
+                },
+                "tasks": {
+                    "type": "array",
+                    "description": "Task ARNs",
+                    "items": { "type": "string" }
+                },
+                "desired_count": {
+                    "type": "integer",
+                    "description": "Desired count for update-service"
+                },
+                "region": {
+                    "type": "string",
+                    "description": "AWS region"
+                },
+                "profile": {
+                    "type": "string",
+                    "description": "AWS profile name"
+                }
+            }),
+            vec!["command"],
+        );
+
+        Self {
+            config: tool_config_with_timeout(
+                "aws_ecs",
+                "AWS ECS: manage clusters, services, and tasks.",
+                parameters,
+                120,
+            ),
+        }
+    }
+}
+
+impl Default for AwsEcsTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for AwsEcsTool {
+    async fn execute(&self, input: ToolInput) -> AofResult<ToolResult> {
+        let command: String = input.get_arg("command")?;
+        let cluster: Option<String> = input.get_arg("cluster").ok();
+        let service: Option<String> = input.get_arg("service").ok();
+        let tasks: Vec<String> = input.get_arg("tasks").unwrap_or_default();
+        let desired_count: Option<i32> = input.get_arg("desired_count").ok();
+        let region: Option<String> = input.get_arg("region").ok();
+        let profile: Option<String> = input.get_arg("profile").ok();
+
+        let mut args = vec!["ecs".to_string(), command.clone()];
+
+        if let Some(ref c) = cluster {
+            args.push("--cluster".to_string());
+            args.push(c.clone());
+        }
+
+        if let Some(ref s) = service {
+            if command.contains("service") {
+                args.push("--services".to_string());
+            } else {
+                args.push("--service".to_string());
+            }
+            args.push(s.clone());
+        }
+
+        if !tasks.is_empty() {
+            args.push("--tasks".to_string());
+            args.extend(tasks);
+        }
+
+        if let Some(dc) = desired_count {
+            args.push("--desired-count".to_string());
+            args.push(dc.to_string());
+        }
+
+        if let Some(ref r) = region {
+            args.push("--region".to_string());
+            args.push(r.clone());
+        }
+
+        if let Some(ref pr) = profile {
+            args.push("--profile".to_string());
+            args.push(pr.clone());
+        }
+
+        args.push("--output".to_string());
+        args.push("json".to_string());
+
+        debug!(args = ?args, "Executing aws ecs");
+
+        let args_str: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        let result = execute_command("aws", &args_str, None, 120).await;
+
+        match result {
+            Ok(output) => {
+                if output.success {
+                    let data = serde_json::from_str(&output.stdout).unwrap_or_else(|_| {
+                        serde_json::json!({ "raw": output.stdout })
+                    });
+
+                    Ok(ToolResult::success(serde_json::json!({
+                        "data": data,
+                        "command": command
+                    })))
+                } else {
+                    Ok(ToolResult::error(format!(
+                        "aws ecs {} failed: {}",
+                        command, output.stderr
+                    )))
+                }
+            }
+            Err(e) => Ok(ToolResult::error(e)),
+        }
+    }
+
+    fn config(&self) -> &ToolConfig {
+        &self.config
+    }
+}

--- a/aof/crates/aof-tools/src/tools/docker.rs
+++ b/aof/crates/aof-tools/src/tools/docker.rs
@@ -1,0 +1,744 @@
+//! Docker Tools
+//!
+//! Tools for Docker container operations.
+//!
+//! ## Available Tools
+//!
+//! - `docker_ps` - List running containers
+//! - `docker_build` - Build images
+//! - `docker_run` - Run containers
+//! - `docker_logs` - Get container logs
+//! - `docker_exec` - Execute commands in containers
+//! - `docker_images` - List images
+//!
+//! ## Prerequisites
+//!
+//! - Docker must be installed and running
+//! - User must have Docker socket access
+//!
+//! ## MCP Alternative
+//!
+//! For MCP-based Docker operations, use a Docker MCP server.
+
+use aof_core::{AofResult, Tool, ToolConfig, ToolInput, ToolResult};
+use async_trait::async_trait;
+use tracing::debug;
+
+use super::common::{execute_command, create_schema, tool_config_with_timeout};
+
+/// Collection of all Docker tools
+pub struct DockerTools;
+
+impl DockerTools {
+    /// Get all Docker tools
+    pub fn all() -> Vec<Box<dyn Tool>> {
+        vec![
+            Box::new(DockerPsTool::new()),
+            Box::new(DockerBuildTool::new()),
+            Box::new(DockerRunTool::new()),
+            Box::new(DockerLogsTool::new()),
+            Box::new(DockerExecTool::new()),
+            Box::new(DockerImagesTool::new()),
+        ]
+    }
+
+    /// Check if Docker is available
+    pub fn is_available() -> bool {
+        which::which("docker").is_ok()
+    }
+}
+
+// ============================================================================
+// Docker PS Tool
+// ============================================================================
+
+/// List Docker containers
+pub struct DockerPsTool {
+    config: ToolConfig,
+}
+
+impl DockerPsTool {
+    pub fn new() -> Self {
+        let parameters = create_schema(
+            serde_json::json!({
+                "all": {
+                    "type": "boolean",
+                    "description": "Show all containers (default shows just running)",
+                    "default": false
+                },
+                "filter": {
+                    "type": "string",
+                    "description": "Filter output (e.g., 'status=running', 'name=web')"
+                },
+                "format": {
+                    "type": "string",
+                    "description": "Output format (json for structured data)",
+                    "default": "json"
+                }
+            }),
+            vec![],
+        );
+
+        Self {
+            config: tool_config_with_timeout(
+                "docker_ps",
+                "List Docker containers. Returns container IDs, names, and status.",
+                parameters,
+                30,
+            ),
+        }
+    }
+}
+
+impl Default for DockerPsTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for DockerPsTool {
+    async fn execute(&self, input: ToolInput) -> AofResult<ToolResult> {
+        let all: bool = input.get_arg("all").unwrap_or(false);
+        let filter: Option<String> = input.get_arg("filter").ok();
+        let format: String = input.get_arg("format").unwrap_or_else(|_| "json".to_string());
+
+        let mut args = vec!["ps".to_string()];
+
+        if all {
+            args.push("-a".to_string());
+        }
+
+        if let Some(ref f) = filter {
+            args.push(format!("--filter={}", f));
+        }
+
+        if format == "json" {
+            args.push("--format={{json .}}".to_string());
+        }
+
+        debug!(args = ?args, "Executing docker ps");
+
+        let args_str: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        let result = execute_command("docker", &args_str, None, 30).await;
+
+        match result {
+            Ok(output) => {
+                if output.success {
+                    // Parse JSON lines output
+                    let containers: Vec<serde_json::Value> = output
+                        .stdout
+                        .lines()
+                        .filter_map(|line| serde_json::from_str(line).ok())
+                        .collect();
+
+                    Ok(ToolResult::success(serde_json::json!({
+                        "containers": containers,
+                        "count": containers.len()
+                    })))
+                } else {
+                    Ok(ToolResult::error(format!(
+                        "docker ps failed: {}",
+                        output.stderr
+                    )))
+                }
+            }
+            Err(e) => Ok(ToolResult::error(e)),
+        }
+    }
+
+    fn config(&self) -> &ToolConfig {
+        &self.config
+    }
+}
+
+// ============================================================================
+// Docker Build Tool
+// ============================================================================
+
+/// Build Docker images
+pub struct DockerBuildTool {
+    config: ToolConfig,
+}
+
+impl DockerBuildTool {
+    pub fn new() -> Self {
+        let parameters = create_schema(
+            serde_json::json!({
+                "path": {
+                    "type": "string",
+                    "description": "Build context path (default: current directory)",
+                    "default": "."
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Image tag (e.g., 'myapp:latest')"
+                },
+                "dockerfile": {
+                    "type": "string",
+                    "description": "Dockerfile path (default: Dockerfile)"
+                },
+                "build_args": {
+                    "type": "object",
+                    "description": "Build arguments",
+                    "additionalProperties": { "type": "string" }
+                },
+                "no_cache": {
+                    "type": "boolean",
+                    "description": "Don't use cache",
+                    "default": false
+                },
+                "target": {
+                    "type": "string",
+                    "description": "Target build stage"
+                },
+                "platform": {
+                    "type": "string",
+                    "description": "Target platform (e.g., 'linux/amd64')"
+                }
+            }),
+            vec!["tag"],
+        );
+
+        Self {
+            config: tool_config_with_timeout(
+                "docker_build",
+                "Build a Docker image from a Dockerfile.",
+                parameters,
+                600, // 10 minute timeout for builds
+            ),
+        }
+    }
+}
+
+impl Default for DockerBuildTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for DockerBuildTool {
+    async fn execute(&self, input: ToolInput) -> AofResult<ToolResult> {
+        let path: String = input.get_arg("path").unwrap_or_else(|_| ".".to_string());
+        let tag: String = input.get_arg("tag")?;
+        let dockerfile: Option<String> = input.get_arg("dockerfile").ok();
+        let build_args: std::collections::HashMap<String, String> = input
+            .get_arg("build_args")
+            .unwrap_or_default();
+        let no_cache: bool = input.get_arg("no_cache").unwrap_or(false);
+        let target: Option<String> = input.get_arg("target").ok();
+        let platform: Option<String> = input.get_arg("platform").ok();
+
+        let mut args = vec!["build".to_string(), "-t".to_string(), tag.clone()];
+
+        if let Some(ref df) = dockerfile {
+            args.push("-f".to_string());
+            args.push(df.clone());
+        }
+
+        for (key, value) in &build_args {
+            args.push("--build-arg".to_string());
+            args.push(format!("{}={}", key, value));
+        }
+
+        if no_cache {
+            args.push("--no-cache".to_string());
+        }
+
+        if let Some(ref t) = target {
+            args.push("--target".to_string());
+            args.push(t.clone());
+        }
+
+        if let Some(ref p) = platform {
+            args.push("--platform".to_string());
+            args.push(p.clone());
+        }
+
+        args.push(path.clone());
+
+        debug!(args = ?args, "Executing docker build");
+
+        let args_str: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        let result = execute_command("docker", &args_str, None, 600).await;
+
+        match result {
+            Ok(output) => {
+                if output.success {
+                    Ok(ToolResult::success(serde_json::json!({
+                        "image": tag,
+                        "built": true,
+                        "output": output.stdout
+                    })))
+                } else {
+                    Ok(ToolResult::error(format!(
+                        "docker build failed: {}",
+                        output.stderr
+                    )))
+                }
+            }
+            Err(e) => Ok(ToolResult::error(e)),
+        }
+    }
+
+    fn config(&self) -> &ToolConfig {
+        &self.config
+    }
+}
+
+// ============================================================================
+// Docker Run Tool
+// ============================================================================
+
+/// Run Docker containers
+pub struct DockerRunTool {
+    config: ToolConfig,
+}
+
+impl DockerRunTool {
+    pub fn new() -> Self {
+        let parameters = create_schema(
+            serde_json::json!({
+                "image": {
+                    "type": "string",
+                    "description": "Image to run"
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Container name"
+                },
+                "command": {
+                    "type": "string",
+                    "description": "Command to run in container"
+                },
+                "detach": {
+                    "type": "boolean",
+                    "description": "Run in background",
+                    "default": false
+                },
+                "rm": {
+                    "type": "boolean",
+                    "description": "Remove container after exit",
+                    "default": true
+                },
+                "ports": {
+                    "type": "array",
+                    "description": "Port mappings (e.g., ['8080:80', '443:443'])",
+                    "items": { "type": "string" }
+                },
+                "volumes": {
+                    "type": "array",
+                    "description": "Volume mounts (e.g., ['/host:/container'])",
+                    "items": { "type": "string" }
+                },
+                "env": {
+                    "type": "object",
+                    "description": "Environment variables",
+                    "additionalProperties": { "type": "string" }
+                },
+                "network": {
+                    "type": "string",
+                    "description": "Network to connect to"
+                }
+            }),
+            vec!["image"],
+        );
+
+        Self {
+            config: tool_config_with_timeout(
+                "docker_run",
+                "Run a Docker container.",
+                parameters,
+                300,
+            ),
+        }
+    }
+}
+
+impl Default for DockerRunTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for DockerRunTool {
+    async fn execute(&self, input: ToolInput) -> AofResult<ToolResult> {
+        let image: String = input.get_arg("image")?;
+        let name: Option<String> = input.get_arg("name").ok();
+        let command: Option<String> = input.get_arg("command").ok();
+        let detach: bool = input.get_arg("detach").unwrap_or(false);
+        let rm: bool = input.get_arg("rm").unwrap_or(true);
+        let ports: Vec<String> = input.get_arg("ports").unwrap_or_default();
+        let volumes: Vec<String> = input.get_arg("volumes").unwrap_or_default();
+        let env: std::collections::HashMap<String, String> = input.get_arg("env").unwrap_or_default();
+        let network: Option<String> = input.get_arg("network").ok();
+
+        let mut args = vec!["run".to_string()];
+
+        if detach {
+            args.push("-d".to_string());
+        }
+
+        if rm {
+            args.push("--rm".to_string());
+        }
+
+        if let Some(ref n) = name {
+            args.push("--name".to_string());
+            args.push(n.clone());
+        }
+
+        for port in &ports {
+            args.push("-p".to_string());
+            args.push(port.clone());
+        }
+
+        for vol in &volumes {
+            args.push("-v".to_string());
+            args.push(vol.clone());
+        }
+
+        for (key, value) in &env {
+            args.push("-e".to_string());
+            args.push(format!("{}={}", key, value));
+        }
+
+        if let Some(ref n) = network {
+            args.push("--network".to_string());
+            args.push(n.clone());
+        }
+
+        args.push(image.clone());
+
+        if let Some(ref cmd) = command {
+            args.extend(cmd.split_whitespace().map(String::from));
+        }
+
+        debug!(args = ?args, "Executing docker run");
+
+        let args_str: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        let result = execute_command("docker", &args_str, None, 300).await;
+
+        match result {
+            Ok(output) => {
+                if output.success {
+                    let container_id = output.stdout.trim().to_string();
+                    Ok(ToolResult::success(serde_json::json!({
+                        "container_id": container_id,
+                        "image": image,
+                        "detached": detach,
+                        "output": if detach { container_id } else { output.stdout }
+                    })))
+                } else {
+                    Ok(ToolResult::error(format!(
+                        "docker run failed: {}",
+                        output.stderr
+                    )))
+                }
+            }
+            Err(e) => Ok(ToolResult::error(e)),
+        }
+    }
+
+    fn config(&self) -> &ToolConfig {
+        &self.config
+    }
+}
+
+// ============================================================================
+// Docker Logs Tool
+// ============================================================================
+
+/// Get container logs
+pub struct DockerLogsTool {
+    config: ToolConfig,
+}
+
+impl DockerLogsTool {
+    pub fn new() -> Self {
+        let parameters = create_schema(
+            serde_json::json!({
+                "container": {
+                    "type": "string",
+                    "description": "Container name or ID"
+                },
+                "tail": {
+                    "type": "integer",
+                    "description": "Number of lines from end",
+                    "default": 100
+                },
+                "since": {
+                    "type": "string",
+                    "description": "Show logs since (e.g., '5m', '1h')"
+                },
+                "timestamps": {
+                    "type": "boolean",
+                    "description": "Show timestamps",
+                    "default": false
+                }
+            }),
+            vec!["container"],
+        );
+
+        Self {
+            config: tool_config_with_timeout(
+                "docker_logs",
+                "Get logs from a Docker container.",
+                parameters,
+                60,
+            ),
+        }
+    }
+}
+
+impl Default for DockerLogsTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for DockerLogsTool {
+    async fn execute(&self, input: ToolInput) -> AofResult<ToolResult> {
+        let container: String = input.get_arg("container")?;
+        let tail: i32 = input.get_arg("tail").unwrap_or(100);
+        let since: Option<String> = input.get_arg("since").ok();
+        let timestamps: bool = input.get_arg("timestamps").unwrap_or(false);
+
+        let mut args = vec!["logs".to_string()];
+
+        args.push(format!("--tail={}", tail));
+
+        if let Some(ref s) = since {
+            args.push(format!("--since={}", s));
+        }
+
+        if timestamps {
+            args.push("--timestamps".to_string());
+        }
+
+        args.push(container.clone());
+
+        debug!(args = ?args, "Executing docker logs");
+
+        let args_str: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        let result = execute_command("docker", &args_str, None, 60).await;
+
+        match result {
+            Ok(output) => {
+                // Docker logs go to stderr for some reason
+                let logs = if output.stdout.is_empty() {
+                    output.stderr.clone()
+                } else {
+                    output.stdout.clone()
+                };
+
+                Ok(ToolResult::success(serde_json::json!({
+                    "logs": logs,
+                    "container": container,
+                    "lines": logs.lines().count()
+                })))
+            }
+            Err(e) => Ok(ToolResult::error(e)),
+        }
+    }
+
+    fn config(&self) -> &ToolConfig {
+        &self.config
+    }
+}
+
+// ============================================================================
+// Docker Exec Tool
+// ============================================================================
+
+/// Execute commands in containers
+pub struct DockerExecTool {
+    config: ToolConfig,
+}
+
+impl DockerExecTool {
+    pub fn new() -> Self {
+        let parameters = create_schema(
+            serde_json::json!({
+                "container": {
+                    "type": "string",
+                    "description": "Container name or ID"
+                },
+                "command": {
+                    "type": "string",
+                    "description": "Command to execute"
+                },
+                "user": {
+                    "type": "string",
+                    "description": "User to run as"
+                },
+                "workdir": {
+                    "type": "string",
+                    "description": "Working directory"
+                }
+            }),
+            vec!["container", "command"],
+        );
+
+        Self {
+            config: tool_config_with_timeout(
+                "docker_exec",
+                "Execute a command in a running container.",
+                parameters,
+                120,
+            ),
+        }
+    }
+}
+
+impl Default for DockerExecTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for DockerExecTool {
+    async fn execute(&self, input: ToolInput) -> AofResult<ToolResult> {
+        let container: String = input.get_arg("container")?;
+        let command: String = input.get_arg("command")?;
+        let user: Option<String> = input.get_arg("user").ok();
+        let workdir: Option<String> = input.get_arg("workdir").ok();
+
+        let mut args = vec!["exec".to_string()];
+
+        if let Some(ref u) = user {
+            args.push("-u".to_string());
+            args.push(u.clone());
+        }
+
+        if let Some(ref w) = workdir {
+            args.push("-w".to_string());
+            args.push(w.clone());
+        }
+
+        args.push(container.clone());
+        args.push("sh".to_string());
+        args.push("-c".to_string());
+        args.push(command.clone());
+
+        debug!(args = ?args, "Executing docker exec");
+
+        let args_str: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        let result = execute_command("docker", &args_str, None, 120).await;
+
+        match result {
+            Ok(output) => {
+                Ok(ToolResult::success(serde_json::json!({
+                    "stdout": output.stdout,
+                    "stderr": output.stderr,
+                    "exit_code": output.exit_code,
+                    "success": output.success,
+                    "container": container,
+                    "command": command
+                })))
+            }
+            Err(e) => Ok(ToolResult::error(e)),
+        }
+    }
+
+    fn config(&self) -> &ToolConfig {
+        &self.config
+    }
+}
+
+// ============================================================================
+// Docker Images Tool
+// ============================================================================
+
+/// List Docker images
+pub struct DockerImagesTool {
+    config: ToolConfig,
+}
+
+impl DockerImagesTool {
+    pub fn new() -> Self {
+        let parameters = create_schema(
+            serde_json::json!({
+                "all": {
+                    "type": "boolean",
+                    "description": "Show all images (including intermediates)",
+                    "default": false
+                },
+                "filter": {
+                    "type": "string",
+                    "description": "Filter output (e.g., 'dangling=true')"
+                }
+            }),
+            vec![],
+        );
+
+        Self {
+            config: tool_config_with_timeout(
+                "docker_images",
+                "List Docker images.",
+                parameters,
+                30,
+            ),
+        }
+    }
+}
+
+impl Default for DockerImagesTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for DockerImagesTool {
+    async fn execute(&self, input: ToolInput) -> AofResult<ToolResult> {
+        let all: bool = input.get_arg("all").unwrap_or(false);
+        let filter: Option<String> = input.get_arg("filter").ok();
+
+        let mut args = vec!["images".to_string(), "--format={{json .}}".to_string()];
+
+        if all {
+            args.push("-a".to_string());
+        }
+
+        if let Some(ref f) = filter {
+            args.push(format!("--filter={}", f));
+        }
+
+        debug!(args = ?args, "Executing docker images");
+
+        let args_str: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        let result = execute_command("docker", &args_str, None, 30).await;
+
+        match result {
+            Ok(output) => {
+                if output.success {
+                    let images: Vec<serde_json::Value> = output
+                        .stdout
+                        .lines()
+                        .filter_map(|line| serde_json::from_str(line).ok())
+                        .collect();
+
+                    Ok(ToolResult::success(serde_json::json!({
+                        "images": images,
+                        "count": images.len()
+                    })))
+                } else {
+                    Ok(ToolResult::error(format!(
+                        "docker images failed: {}",
+                        output.stderr
+                    )))
+                }
+            }
+            Err(e) => Ok(ToolResult::error(e)),
+        }
+    }
+
+    fn config(&self) -> &ToolConfig {
+        &self.config
+    }
+}

--- a/aof/crates/aof-tools/src/tools/file.rs
+++ b/aof/crates/aof-tools/src/tools/file.rs
@@ -1,0 +1,541 @@
+//! File System Tools
+//!
+//! Tools for file system operations including reading, writing, listing, and searching files.
+//!
+//! ## Available Tools
+//!
+//! - `read_file` - Read contents of a file
+//! - `write_file` - Write content to a file
+//! - `list_directory` - List contents of a directory
+//! - `search_files` - Search for files matching a pattern
+//!
+//! ## MCP Alternative
+//!
+//! If you prefer MCP, use the filesystem MCP server:
+//! ```yaml
+//! mcp_servers:
+//!   - name: filesystem
+//!     transport: stdio
+//!     command: npx
+//!     args: ["@modelcontextprotocol/server-filesystem", "/workspace"]
+//! ```
+
+use aof_core::{AofResult, Tool, ToolConfig, ToolInput, ToolResult};
+use async_trait::async_trait;
+use std::path::Path;
+use tokio::fs;
+use tokio::io::AsyncReadExt;
+use tracing::debug;
+
+use super::common::{create_schema, tool_config};
+
+/// Collection of all file tools
+pub struct FileTools;
+
+impl FileTools {
+    /// Get all file tools
+    pub fn all() -> Vec<Box<dyn Tool>> {
+        vec![
+            Box::new(ReadFileTool::new()),
+            Box::new(WriteFileTool::new()),
+            Box::new(ListDirTool::new()),
+            Box::new(SearchFilesTool::new()),
+        ]
+    }
+}
+
+// ============================================================================
+// Read File Tool
+// ============================================================================
+
+/// Read the contents of a file
+pub struct ReadFileTool {
+    config: ToolConfig,
+}
+
+impl ReadFileTool {
+    pub fn new() -> Self {
+        let parameters = create_schema(
+            serde_json::json!({
+                "path": {
+                    "type": "string",
+                    "description": "Path to the file to read"
+                },
+                "encoding": {
+                    "type": "string",
+                    "description": "File encoding (default: utf-8)",
+                    "default": "utf-8"
+                },
+                "max_bytes": {
+                    "type": "integer",
+                    "description": "Maximum bytes to read (default: 1MB)",
+                    "default": 1048576
+                }
+            }),
+            vec!["path"],
+        );
+
+        Self {
+            config: tool_config(
+                "read_file",
+                "Read the contents of a file. Returns the file content as a string.",
+                parameters,
+            ),
+        }
+    }
+}
+
+impl Default for ReadFileTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for ReadFileTool {
+    async fn execute(&self, input: ToolInput) -> AofResult<ToolResult> {
+        let path: String = input.get_arg("path")?;
+        let max_bytes: usize = input.get_arg("max_bytes").unwrap_or(1048576);
+
+        debug!(path = %path, "Reading file");
+
+        let path = Path::new(&path);
+        if !path.exists() {
+            return Ok(ToolResult::error(format!("File not found: {}", path.display())));
+        }
+
+        let mut file = match fs::File::open(path).await {
+            Ok(f) => f,
+            Err(e) => return Ok(ToolResult::error(format!("Failed to open file: {}", e))),
+        };
+
+        let metadata = file.metadata().await.ok();
+        let file_size = metadata.as_ref().map(|m| m.len()).unwrap_or(0);
+
+        let mut buffer = vec![0u8; max_bytes.min(file_size as usize)];
+        let bytes_read = match file.read(&mut buffer).await {
+            Ok(n) => n,
+            Err(e) => return Ok(ToolResult::error(format!("Failed to read file: {}", e))),
+        };
+
+        buffer.truncate(bytes_read);
+
+        let content = String::from_utf8_lossy(&buffer).to_string();
+        let truncated = bytes_read < file_size as usize;
+
+        Ok(ToolResult::success(serde_json::json!({
+            "content": content,
+            "path": path.display().to_string(),
+            "size": file_size,
+            "bytes_read": bytes_read,
+            "truncated": truncated
+        })))
+    }
+
+    fn config(&self) -> &ToolConfig {
+        &self.config
+    }
+}
+
+// ============================================================================
+// Write File Tool
+// ============================================================================
+
+/// Write content to a file
+pub struct WriteFileTool {
+    config: ToolConfig,
+}
+
+impl WriteFileTool {
+    pub fn new() -> Self {
+        let parameters = create_schema(
+            serde_json::json!({
+                "path": {
+                    "type": "string",
+                    "description": "Path to the file to write"
+                },
+                "content": {
+                    "type": "string",
+                    "description": "Content to write to the file"
+                },
+                "append": {
+                    "type": "boolean",
+                    "description": "Append to file instead of overwriting (default: false)",
+                    "default": false
+                },
+                "create_dirs": {
+                    "type": "boolean",
+                    "description": "Create parent directories if they don't exist (default: true)",
+                    "default": true
+                }
+            }),
+            vec!["path", "content"],
+        );
+
+        Self {
+            config: tool_config(
+                "write_file",
+                "Write content to a file. Creates the file if it doesn't exist.",
+                parameters,
+            ),
+        }
+    }
+}
+
+impl Default for WriteFileTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for WriteFileTool {
+    async fn execute(&self, input: ToolInput) -> AofResult<ToolResult> {
+        let path: String = input.get_arg("path")?;
+        let content: String = input.get_arg("content")?;
+        let append: bool = input.get_arg("append").unwrap_or(false);
+        let create_dirs: bool = input.get_arg("create_dirs").unwrap_or(true);
+
+        debug!(path = %path, append = %append, "Writing file");
+
+        let path = Path::new(&path);
+
+        // Create parent directories if needed
+        if create_dirs {
+            if let Some(parent) = path.parent() {
+                if !parent.exists() {
+                    if let Err(e) = fs::create_dir_all(parent).await {
+                        return Ok(ToolResult::error(format!("Failed to create directories: {}", e)));
+                    }
+                }
+            }
+        }
+
+        let result = if append {
+            use tokio::io::AsyncWriteExt;
+            let file = fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(path)
+                .await;
+            match file {
+                Ok(mut f) => f.write_all(content.as_bytes()).await,
+                Err(e) => return Ok(ToolResult::error(format!("Failed to open file: {}", e))),
+            }
+        } else {
+            fs::write(path, &content).await
+        };
+
+        match result {
+            Ok(_) => Ok(ToolResult::success(serde_json::json!({
+                "path": path.display().to_string(),
+                "bytes_written": content.len(),
+                "appended": append
+            }))),
+            Err(e) => Ok(ToolResult::error(format!("Failed to write file: {}", e))),
+        }
+    }
+
+    fn config(&self) -> &ToolConfig {
+        &self.config
+    }
+}
+
+// ============================================================================
+// List Directory Tool
+// ============================================================================
+
+/// List contents of a directory
+pub struct ListDirTool {
+    config: ToolConfig,
+}
+
+impl ListDirTool {
+    pub fn new() -> Self {
+        let parameters = create_schema(
+            serde_json::json!({
+                "path": {
+                    "type": "string",
+                    "description": "Path to the directory to list"
+                },
+                "recursive": {
+                    "type": "boolean",
+                    "description": "List recursively (default: false)",
+                    "default": false
+                },
+                "include_hidden": {
+                    "type": "boolean",
+                    "description": "Include hidden files (default: false)",
+                    "default": false
+                },
+                "max_depth": {
+                    "type": "integer",
+                    "description": "Maximum recursion depth (default: 3)",
+                    "default": 3
+                }
+            }),
+            vec!["path"],
+        );
+
+        Self {
+            config: tool_config(
+                "list_directory",
+                "List contents of a directory. Returns file names, sizes, and types.",
+                parameters,
+            ),
+        }
+    }
+
+    fn list_entries_sync(
+        path: &Path,
+        recursive: bool,
+        include_hidden: bool,
+        max_depth: usize,
+        current_depth: usize,
+    ) -> AofResult<Vec<serde_json::Value>> {
+        let mut entries = Vec::new();
+
+        let dir = match std::fs::read_dir(path) {
+            Ok(d) => d,
+            Err(e) => return Err(aof_core::AofError::tool(format!("Failed to read directory: {}", e))),
+        };
+
+        for entry in dir {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
+
+            let name = entry.file_name().to_string_lossy().to_string();
+
+            // Skip hidden files if not requested
+            if !include_hidden && name.starts_with('.') {
+                continue;
+            }
+
+            let metadata = entry.metadata().ok();
+            let file_type = if metadata.as_ref().map(|m| m.is_dir()).unwrap_or(false) {
+                "directory"
+            } else if metadata.as_ref().map(|m| m.file_type().is_symlink()).unwrap_or(false) {
+                "symlink"
+            } else {
+                "file"
+            };
+
+            let mut entry_info = serde_json::json!({
+                "name": name,
+                "path": entry.path().display().to_string(),
+                "type": file_type,
+                "size": metadata.as_ref().map(|m| m.len()).unwrap_or(0)
+            });
+
+            // Recursively list subdirectories
+            if recursive && file_type == "directory" && current_depth < max_depth {
+                if let Ok(children) = Self::list_entries_sync(
+                    &entry.path(), true, include_hidden, max_depth, current_depth + 1
+                ) {
+                    entry_info["children"] = serde_json::json!(children);
+                }
+            }
+
+            entries.push(entry_info);
+        }
+
+        Ok(entries)
+    }
+}
+
+impl Default for ListDirTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for ListDirTool {
+    async fn execute(&self, input: ToolInput) -> AofResult<ToolResult> {
+        let path: String = input.get_arg("path")?;
+        let recursive: bool = input.get_arg("recursive").unwrap_or(false);
+        let include_hidden: bool = input.get_arg("include_hidden").unwrap_or(false);
+        let max_depth: usize = input.get_arg("max_depth").unwrap_or(3);
+
+        debug!(path = %path, recursive = %recursive, "Listing directory");
+
+        let path = Path::new(&path);
+        if !path.exists() {
+            return Ok(ToolResult::error(format!("Directory not found: {}", path.display())));
+        }
+
+        if !path.is_dir() {
+            return Ok(ToolResult::error(format!("Not a directory: {}", path.display())));
+        }
+
+        match Self::list_entries_sync(path, recursive, include_hidden, max_depth, 0) {
+            Ok(entries) => Ok(ToolResult::success(serde_json::json!({
+                "path": path.display().to_string(),
+                "entries": entries,
+                "count": entries.len()
+            }))),
+            Err(e) => Ok(ToolResult::error(e.to_string())),
+        }
+    }
+
+    fn config(&self) -> &ToolConfig {
+        &self.config
+    }
+}
+
+// ============================================================================
+// Search Files Tool
+// ============================================================================
+
+/// Search for files matching a pattern
+pub struct SearchFilesTool {
+    config: ToolConfig,
+}
+
+impl SearchFilesTool {
+    pub fn new() -> Self {
+        let parameters = create_schema(
+            serde_json::json!({
+                "pattern": {
+                    "type": "string",
+                    "description": "Glob pattern to match (e.g., '**/*.rs', 'src/*.ts')"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Base path to search from (default: current directory)",
+                    "default": "."
+                },
+                "max_results": {
+                    "type": "integer",
+                    "description": "Maximum number of results (default: 100)",
+                    "default": 100
+                }
+            }),
+            vec!["pattern"],
+        );
+
+        Self {
+            config: tool_config(
+                "search_files",
+                "Search for files matching a glob pattern. Returns matching file paths.",
+                parameters,
+            ),
+        }
+    }
+}
+
+impl Default for SearchFilesTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for SearchFilesTool {
+    async fn execute(&self, input: ToolInput) -> AofResult<ToolResult> {
+        let pattern: String = input.get_arg("pattern")?;
+        let base_path: String = input.get_arg("path").unwrap_or_else(|_| ".".to_string());
+        let max_results: usize = input.get_arg("max_results").unwrap_or(100);
+
+        debug!(pattern = %pattern, base_path = %base_path, "Searching files");
+
+        let full_pattern = if pattern.starts_with('/') || pattern.starts_with('.') {
+            pattern
+        } else {
+            format!("{}/{}", base_path, pattern)
+        };
+
+        let matches: Vec<String> = glob::glob(&full_pattern)
+            .map_err(|e| aof_core::AofError::tool(format!("Invalid pattern: {}", e)))?
+            .filter_map(|r| r.ok())
+            .take(max_results)
+            .map(|p| p.display().to_string())
+            .collect();
+
+        Ok(ToolResult::success(serde_json::json!({
+            "pattern": full_pattern,
+            "matches": matches,
+            "count": matches.len(),
+            "truncated": matches.len() >= max_results
+        })))
+    }
+
+    fn config(&self) -> &ToolConfig {
+        &self.config
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn test_read_file() {
+        let dir = TempDir::new().unwrap();
+        let file_path = dir.path().join("test.txt");
+        std::fs::write(&file_path, "Hello, World!").unwrap();
+
+        let tool = ReadFileTool::new();
+        let input = ToolInput::new(serde_json::json!({
+            "path": file_path.display().to_string()
+        }));
+
+        let result = tool.execute(input).await.unwrap();
+        assert!(result.success);
+        assert_eq!(result.data["content"], "Hello, World!");
+    }
+
+    #[tokio::test]
+    async fn test_write_file() {
+        let dir = TempDir::new().unwrap();
+        let file_path = dir.path().join("output.txt");
+
+        let tool = WriteFileTool::new();
+        let input = ToolInput::new(serde_json::json!({
+            "path": file_path.display().to_string(),
+            "content": "Test content"
+        }));
+
+        let result = tool.execute(input).await.unwrap();
+        assert!(result.success);
+
+        let content = std::fs::read_to_string(&file_path).unwrap();
+        assert_eq!(content, "Test content");
+    }
+
+    #[tokio::test]
+    async fn test_list_directory() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("file1.txt"), "content1").unwrap();
+        std::fs::write(dir.path().join("file2.txt"), "content2").unwrap();
+
+        let tool = ListDirTool::new();
+        let input = ToolInput::new(serde_json::json!({
+            "path": dir.path().display().to_string()
+        }));
+
+        let result = tool.execute(input).await.unwrap();
+        assert!(result.success);
+        assert_eq!(result.data["count"], 2);
+    }
+
+    #[tokio::test]
+    async fn test_search_files() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("test.rs"), "fn main() {}").unwrap();
+        std::fs::write(dir.path().join("test.txt"), "hello").unwrap();
+
+        let tool = SearchFilesTool::new();
+        let input = ToolInput::new(serde_json::json!({
+            "pattern": "*.rs",
+            "path": dir.path().display().to_string()
+        }));
+
+        let result = tool.execute(input).await.unwrap();
+        assert!(result.success);
+        assert_eq!(result.data["count"], 1);
+    }
+}

--- a/aof/crates/aof-tools/src/tools/git.rs
+++ b/aof/crates/aof-tools/src/tools/git.rs
@@ -1,0 +1,1001 @@
+//! Git Tools
+//!
+//! Tools for Git repository operations.
+//!
+//! ## Available Tools
+//!
+//! - `git_status` - Show working tree status
+//! - `git_diff` - Show changes
+//! - `git_log` - Show commit history
+//! - `git_commit` - Create commits
+//! - `git_branch` - List/create branches
+//! - `git_checkout` - Switch branches
+//! - `git_pull` - Pull changes
+//! - `git_push` - Push changes
+//!
+//! ## Prerequisites
+//!
+//! - Git must be installed and in PATH
+//! - Repository must be initialized
+//!
+//! ## MCP Alternative
+//!
+//! For MCP-based Git operations, use the Git MCP server.
+
+use aof_core::{AofResult, Tool, ToolConfig, ToolInput, ToolResult};
+use async_trait::async_trait;
+use tracing::debug;
+
+use super::common::{execute_command, create_schema, tool_config_with_timeout};
+
+/// Collection of all Git tools
+pub struct GitTools;
+
+impl GitTools {
+    /// Get all Git tools
+    pub fn all() -> Vec<Box<dyn Tool>> {
+        vec![
+            Box::new(GitStatusTool::new()),
+            Box::new(GitDiffTool::new()),
+            Box::new(GitLogTool::new()),
+            Box::new(GitCommitTool::new()),
+            Box::new(GitBranchTool::new()),
+            Box::new(GitCheckoutTool::new()),
+            Box::new(GitPullTool::new()),
+            Box::new(GitPushTool::new()),
+        ]
+    }
+
+    /// Check if git is available
+    pub fn is_available() -> bool {
+        which::which("git").is_ok()
+    }
+}
+
+// ============================================================================
+// Git Status Tool
+// ============================================================================
+
+/// Show working tree status
+pub struct GitStatusTool {
+    config: ToolConfig,
+}
+
+impl GitStatusTool {
+    pub fn new() -> Self {
+        let parameters = create_schema(
+            serde_json::json!({
+                "path": {
+                    "type": "string",
+                    "description": "Repository path (default: current directory)",
+                    "default": "."
+                },
+                "short": {
+                    "type": "boolean",
+                    "description": "Use short format",
+                    "default": false
+                },
+                "porcelain": {
+                    "type": "boolean",
+                    "description": "Machine-readable output",
+                    "default": true
+                }
+            }),
+            vec![],
+        );
+
+        Self {
+            config: tool_config_with_timeout(
+                "git_status",
+                "Show the working tree status. Lists modified, staged, and untracked files.",
+                parameters,
+                30,
+            ),
+        }
+    }
+}
+
+impl Default for GitStatusTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for GitStatusTool {
+    async fn execute(&self, input: ToolInput) -> AofResult<ToolResult> {
+        let path: String = input.get_arg("path").unwrap_or_else(|_| ".".to_string());
+        let short: bool = input.get_arg("short").unwrap_or(false);
+        let porcelain: bool = input.get_arg("porcelain").unwrap_or(true);
+
+        let mut args = vec!["status"];
+
+        if short {
+            args.push("-s");
+        }
+
+        if porcelain {
+            args.push("--porcelain=v1");
+        }
+
+        debug!(args = ?args, path = %path, "Executing git status");
+
+        let result = execute_command("git", &args, Some(&path), 30).await;
+
+        match result {
+            Ok(output) => {
+                if output.success {
+                    // Parse porcelain output
+                    let files: Vec<serde_json::Value> = if porcelain {
+                        output
+                            .stdout
+                            .lines()
+                            .filter(|l| !l.is_empty())
+                            .map(|line| {
+                                let status = &line[..2];
+                                let file = &line[3..];
+                                serde_json::json!({
+                                    "status": status.trim(),
+                                    "file": file
+                                })
+                            })
+                            .collect()
+                    } else {
+                        vec![]
+                    };
+
+                    Ok(ToolResult::success(serde_json::json!({
+                        "files": files,
+                        "count": files.len(),
+                        "clean": files.is_empty(),
+                        "raw": output.stdout
+                    })))
+                } else {
+                    Ok(ToolResult::error(format!(
+                        "git status failed: {}",
+                        output.stderr
+                    )))
+                }
+            }
+            Err(e) => Ok(ToolResult::error(e)),
+        }
+    }
+
+    fn config(&self) -> &ToolConfig {
+        &self.config
+    }
+}
+
+// ============================================================================
+// Git Diff Tool
+// ============================================================================
+
+/// Show changes
+pub struct GitDiffTool {
+    config: ToolConfig,
+}
+
+impl GitDiffTool {
+    pub fn new() -> Self {
+        let parameters = create_schema(
+            serde_json::json!({
+                "path": {
+                    "type": "string",
+                    "description": "Repository path",
+                    "default": "."
+                },
+                "file": {
+                    "type": "string",
+                    "description": "Specific file to diff"
+                },
+                "staged": {
+                    "type": "boolean",
+                    "description": "Show staged changes",
+                    "default": false
+                },
+                "commit": {
+                    "type": "string",
+                    "description": "Compare with specific commit"
+                },
+                "stat": {
+                    "type": "boolean",
+                    "description": "Show diffstat",
+                    "default": false
+                }
+            }),
+            vec![],
+        );
+
+        Self {
+            config: tool_config_with_timeout(
+                "git_diff",
+                "Show changes between commits, commit and working tree, etc.",
+                parameters,
+                60,
+            ),
+        }
+    }
+}
+
+impl Default for GitDiffTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for GitDiffTool {
+    async fn execute(&self, input: ToolInput) -> AofResult<ToolResult> {
+        let path: String = input.get_arg("path").unwrap_or_else(|_| ".".to_string());
+        let file: Option<String> = input.get_arg("file").ok();
+        let staged: bool = input.get_arg("staged").unwrap_or(false);
+        let commit: Option<String> = input.get_arg("commit").ok();
+        let stat: bool = input.get_arg("stat").unwrap_or(false);
+
+        let mut args = vec!["diff".to_string()];
+
+        if staged {
+            args.push("--staged".to_string());
+        }
+
+        if let Some(ref c) = commit {
+            args.push(c.clone());
+        }
+
+        if stat {
+            args.push("--stat".to_string());
+        }
+
+        if let Some(ref f) = file {
+            args.push("--".to_string());
+            args.push(f.clone());
+        }
+
+        debug!(args = ?args, path = %path, "Executing git diff");
+
+        let args_str: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        let result = execute_command("git", &args_str, Some(&path), 60).await;
+
+        match result {
+            Ok(output) => {
+                if output.success {
+                    Ok(ToolResult::success(serde_json::json!({
+                        "diff": output.stdout,
+                        "has_changes": !output.stdout.is_empty(),
+                        "lines": output.stdout.lines().count()
+                    })))
+                } else {
+                    Ok(ToolResult::error(format!(
+                        "git diff failed: {}",
+                        output.stderr
+                    )))
+                }
+            }
+            Err(e) => Ok(ToolResult::error(e)),
+        }
+    }
+
+    fn config(&self) -> &ToolConfig {
+        &self.config
+    }
+}
+
+// ============================================================================
+// Git Log Tool
+// ============================================================================
+
+/// Show commit history
+pub struct GitLogTool {
+    config: ToolConfig,
+}
+
+impl GitLogTool {
+    pub fn new() -> Self {
+        let parameters = create_schema(
+            serde_json::json!({
+                "path": {
+                    "type": "string",
+                    "description": "Repository path",
+                    "default": "."
+                },
+                "count": {
+                    "type": "integer",
+                    "description": "Number of commits to show",
+                    "default": 10
+                },
+                "oneline": {
+                    "type": "boolean",
+                    "description": "One line per commit",
+                    "default": true
+                },
+                "author": {
+                    "type": "string",
+                    "description": "Filter by author"
+                },
+                "since": {
+                    "type": "string",
+                    "description": "Show commits since date (e.g., '2024-01-01')"
+                },
+                "file": {
+                    "type": "string",
+                    "description": "Show commits for specific file"
+                }
+            }),
+            vec![],
+        );
+
+        Self {
+            config: tool_config_with_timeout(
+                "git_log",
+                "Show commit logs.",
+                parameters,
+                30,
+            ),
+        }
+    }
+}
+
+impl Default for GitLogTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for GitLogTool {
+    async fn execute(&self, input: ToolInput) -> AofResult<ToolResult> {
+        let path: String = input.get_arg("path").unwrap_or_else(|_| ".".to_string());
+        let count: i32 = input.get_arg("count").unwrap_or(10);
+        let oneline: bool = input.get_arg("oneline").unwrap_or(true);
+        let author: Option<String> = input.get_arg("author").ok();
+        let since: Option<String> = input.get_arg("since").ok();
+        let file: Option<String> = input.get_arg("file").ok();
+
+        let mut args = vec!["log".to_string(), format!("-{}", count)];
+
+        if oneline {
+            args.push("--oneline".to_string());
+        } else {
+            args.push("--format=%H|%an|%ae|%at|%s".to_string());
+        }
+
+        if let Some(ref a) = author {
+            args.push(format!("--author={}", a));
+        }
+
+        if let Some(ref s) = since {
+            args.push(format!("--since={}", s));
+        }
+
+        if let Some(ref f) = file {
+            args.push("--".to_string());
+            args.push(f.clone());
+        }
+
+        debug!(args = ?args, path = %path, "Executing git log");
+
+        let args_str: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        let result = execute_command("git", &args_str, Some(&path), 30).await;
+
+        match result {
+            Ok(output) => {
+                if output.success {
+                    let commits: Vec<serde_json::Value> = if oneline {
+                        output
+                            .stdout
+                            .lines()
+                            .filter(|l| !l.is_empty())
+                            .map(|line| {
+                                let parts: Vec<&str> = line.splitn(2, ' ').collect();
+                                serde_json::json!({
+                                    "hash": parts.first().unwrap_or(&""),
+                                    "message": parts.get(1).unwrap_or(&"")
+                                })
+                            })
+                            .collect()
+                    } else {
+                        output
+                            .stdout
+                            .lines()
+                            .filter(|l| !l.is_empty())
+                            .filter_map(|line| {
+                                let parts: Vec<&str> = line.split('|').collect();
+                                if parts.len() >= 5 {
+                                    Some(serde_json::json!({
+                                        "hash": parts[0],
+                                        "author": parts[1],
+                                        "email": parts[2],
+                                        "timestamp": parts[3],
+                                        "message": parts[4]
+                                    }))
+                                } else {
+                                    None
+                                }
+                            })
+                            .collect()
+                    };
+
+                    Ok(ToolResult::success(serde_json::json!({
+                        "commits": commits,
+                        "count": commits.len()
+                    })))
+                } else {
+                    Ok(ToolResult::error(format!(
+                        "git log failed: {}",
+                        output.stderr
+                    )))
+                }
+            }
+            Err(e) => Ok(ToolResult::error(e)),
+        }
+    }
+
+    fn config(&self) -> &ToolConfig {
+        &self.config
+    }
+}
+
+// ============================================================================
+// Git Commit Tool
+// ============================================================================
+
+/// Create commits
+pub struct GitCommitTool {
+    config: ToolConfig,
+}
+
+impl GitCommitTool {
+    pub fn new() -> Self {
+        let parameters = create_schema(
+            serde_json::json!({
+                "message": {
+                    "type": "string",
+                    "description": "Commit message"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Repository path",
+                    "default": "."
+                },
+                "all": {
+                    "type": "boolean",
+                    "description": "Stage all modified files",
+                    "default": false
+                },
+                "files": {
+                    "type": "array",
+                    "description": "Specific files to commit",
+                    "items": { "type": "string" }
+                }
+            }),
+            vec!["message"],
+        );
+
+        Self {
+            config: tool_config_with_timeout(
+                "git_commit",
+                "Record changes to the repository.",
+                parameters,
+                60,
+            ),
+        }
+    }
+}
+
+impl Default for GitCommitTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for GitCommitTool {
+    async fn execute(&self, input: ToolInput) -> AofResult<ToolResult> {
+        let message: String = input.get_arg("message")?;
+        let path: String = input.get_arg("path").unwrap_or_else(|_| ".".to_string());
+        let all: bool = input.get_arg("all").unwrap_or(false);
+        let files: Vec<String> = input.get_arg("files").unwrap_or_default();
+
+        // First, add files if specified
+        if !files.is_empty() {
+            let mut add_args = vec!["add".to_string()];
+            add_args.extend(files.clone());
+            let add_args_str: Vec<&str> = add_args.iter().map(|s| s.as_str()).collect();
+            let _ = execute_command("git", &add_args_str, Some(&path), 30).await;
+        }
+
+        let mut args = vec!["commit".to_string()];
+
+        if all {
+            args.push("-a".to_string());
+        }
+
+        args.push("-m".to_string());
+        args.push(message.clone());
+
+        debug!(args = ?args, path = %path, "Executing git commit");
+
+        let args_str: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        let result = execute_command("git", &args_str, Some(&path), 60).await;
+
+        match result {
+            Ok(output) => {
+                if output.success {
+                    // Get the commit hash
+                    let hash_result = execute_command(
+                        "git",
+                        &["rev-parse", "HEAD"],
+                        Some(&path),
+                        10,
+                    )
+                    .await;
+                    let hash = hash_result
+                        .map(|o| o.stdout.trim().to_string())
+                        .unwrap_or_default();
+
+                    Ok(ToolResult::success(serde_json::json!({
+                        "committed": true,
+                        "hash": hash,
+                        "message": message,
+                        "output": output.stdout
+                    })))
+                } else {
+                    Ok(ToolResult::error(format!(
+                        "git commit failed: {}",
+                        output.stderr
+                    )))
+                }
+            }
+            Err(e) => Ok(ToolResult::error(e)),
+        }
+    }
+
+    fn config(&self) -> &ToolConfig {
+        &self.config
+    }
+}
+
+// ============================================================================
+// Git Branch Tool
+// ============================================================================
+
+/// List or create branches
+pub struct GitBranchTool {
+    config: ToolConfig,
+}
+
+impl GitBranchTool {
+    pub fn new() -> Self {
+        let parameters = create_schema(
+            serde_json::json!({
+                "path": {
+                    "type": "string",
+                    "description": "Repository path",
+                    "default": "."
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Branch name to create"
+                },
+                "delete": {
+                    "type": "string",
+                    "description": "Branch name to delete"
+                },
+                "all": {
+                    "type": "boolean",
+                    "description": "List all branches including remotes",
+                    "default": false
+                }
+            }),
+            vec![],
+        );
+
+        Self {
+            config: tool_config_with_timeout(
+                "git_branch",
+                "List, create, or delete branches.",
+                parameters,
+                30,
+            ),
+        }
+    }
+}
+
+impl Default for GitBranchTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for GitBranchTool {
+    async fn execute(&self, input: ToolInput) -> AofResult<ToolResult> {
+        let path: String = input.get_arg("path").unwrap_or_else(|_| ".".to_string());
+        let name: Option<String> = input.get_arg("name").ok();
+        let delete: Option<String> = input.get_arg("delete").ok();
+        let all: bool = input.get_arg("all").unwrap_or(false);
+
+        let args: Vec<&str> = if let Some(ref n) = name {
+            vec!["branch", n]
+        } else if let Some(ref d) = delete {
+            vec!["branch", "-d", d]
+        } else if all {
+            vec!["branch", "-a"]
+        } else {
+            vec!["branch"]
+        };
+
+        debug!(args = ?args, path = %path, "Executing git branch");
+
+        let result = execute_command("git", &args, Some(&path), 30).await;
+
+        match result {
+            Ok(output) => {
+                if output.success {
+                    if name.is_some() {
+                        Ok(ToolResult::success(serde_json::json!({
+                            "created": true,
+                            "branch": name
+                        })))
+                    } else if delete.is_some() {
+                        Ok(ToolResult::success(serde_json::json!({
+                            "deleted": true,
+                            "branch": delete
+                        })))
+                    } else {
+                        let branches: Vec<serde_json::Value> = output
+                            .stdout
+                            .lines()
+                            .filter(|l| !l.is_empty())
+                            .map(|line| {
+                                let current = line.starts_with('*');
+                                let name = line.trim_start_matches('*').trim();
+                                serde_json::json!({
+                                    "name": name,
+                                    "current": current
+                                })
+                            })
+                            .collect();
+
+                        Ok(ToolResult::success(serde_json::json!({
+                            "branches": branches,
+                            "count": branches.len()
+                        })))
+                    }
+                } else {
+                    Ok(ToolResult::error(format!(
+                        "git branch failed: {}",
+                        output.stderr
+                    )))
+                }
+            }
+            Err(e) => Ok(ToolResult::error(e)),
+        }
+    }
+
+    fn config(&self) -> &ToolConfig {
+        &self.config
+    }
+}
+
+// ============================================================================
+// Git Checkout Tool
+// ============================================================================
+
+/// Switch branches
+pub struct GitCheckoutTool {
+    config: ToolConfig,
+}
+
+impl GitCheckoutTool {
+    pub fn new() -> Self {
+        let parameters = create_schema(
+            serde_json::json!({
+                "branch": {
+                    "type": "string",
+                    "description": "Branch to checkout"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Repository path",
+                    "default": "."
+                },
+                "create": {
+                    "type": "boolean",
+                    "description": "Create branch if it doesn't exist",
+                    "default": false
+                },
+                "file": {
+                    "type": "string",
+                    "description": "Checkout specific file from HEAD"
+                }
+            }),
+            vec![],
+        );
+
+        Self {
+            config: tool_config_with_timeout(
+                "git_checkout",
+                "Switch branches or restore working tree files.",
+                parameters,
+                30,
+            ),
+        }
+    }
+}
+
+impl Default for GitCheckoutTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for GitCheckoutTool {
+    async fn execute(&self, input: ToolInput) -> AofResult<ToolResult> {
+        let branch: Option<String> = input.get_arg("branch").ok();
+        let path: String = input.get_arg("path").unwrap_or_else(|_| ".".to_string());
+        let create: bool = input.get_arg("create").unwrap_or(false);
+        let file: Option<String> = input.get_arg("file").ok();
+
+        if branch.is_none() && file.is_none() {
+            return Ok(ToolResult::error("Either 'branch' or 'file' is required"));
+        }
+
+        let args: Vec<String> = if let Some(ref f) = file {
+            vec!["checkout".to_string(), "--".to_string(), f.clone()]
+        } else if let Some(ref b) = branch {
+            if create {
+                vec!["checkout".to_string(), "-b".to_string(), b.clone()]
+            } else {
+                vec!["checkout".to_string(), b.clone()]
+            }
+        } else {
+            return Ok(ToolResult::error("Invalid arguments"));
+        };
+
+        debug!(args = ?args, path = %path, "Executing git checkout");
+
+        let args_str: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        let result = execute_command("git", &args_str, Some(&path), 30).await;
+
+        match result {
+            Ok(output) => {
+                if output.success {
+                    Ok(ToolResult::success(serde_json::json!({
+                        "success": true,
+                        "branch": branch,
+                        "file": file,
+                        "created": create
+                    })))
+                } else {
+                    Ok(ToolResult::error(format!(
+                        "git checkout failed: {}",
+                        output.stderr
+                    )))
+                }
+            }
+            Err(e) => Ok(ToolResult::error(e)),
+        }
+    }
+
+    fn config(&self) -> &ToolConfig {
+        &self.config
+    }
+}
+
+// ============================================================================
+// Git Pull Tool
+// ============================================================================
+
+/// Pull changes
+pub struct GitPullTool {
+    config: ToolConfig,
+}
+
+impl GitPullTool {
+    pub fn new() -> Self {
+        let parameters = create_schema(
+            serde_json::json!({
+                "path": {
+                    "type": "string",
+                    "description": "Repository path",
+                    "default": "."
+                },
+                "remote": {
+                    "type": "string",
+                    "description": "Remote name",
+                    "default": "origin"
+                },
+                "branch": {
+                    "type": "string",
+                    "description": "Branch to pull"
+                },
+                "rebase": {
+                    "type": "boolean",
+                    "description": "Rebase instead of merge",
+                    "default": false
+                }
+            }),
+            vec![],
+        );
+
+        Self {
+            config: tool_config_with_timeout(
+                "git_pull",
+                "Fetch from and integrate with another repository or branch.",
+                parameters,
+                120,
+            ),
+        }
+    }
+}
+
+impl Default for GitPullTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for GitPullTool {
+    async fn execute(&self, input: ToolInput) -> AofResult<ToolResult> {
+        let path: String = input.get_arg("path").unwrap_or_else(|_| ".".to_string());
+        let remote: String = input.get_arg("remote").unwrap_or_else(|_| "origin".to_string());
+        let branch: Option<String> = input.get_arg("branch").ok();
+        let rebase: bool = input.get_arg("rebase").unwrap_or(false);
+
+        let mut args = vec!["pull".to_string()];
+
+        if rebase {
+            args.push("--rebase".to_string());
+        }
+
+        args.push(remote.clone());
+
+        if let Some(ref b) = branch {
+            args.push(b.clone());
+        }
+
+        debug!(args = ?args, path = %path, "Executing git pull");
+
+        let args_str: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        let result = execute_command("git", &args_str, Some(&path), 120).await;
+
+        match result {
+            Ok(output) => {
+                if output.success {
+                    Ok(ToolResult::success(serde_json::json!({
+                        "pulled": true,
+                        "remote": remote,
+                        "branch": branch,
+                        "output": output.stdout
+                    })))
+                } else {
+                    Ok(ToolResult::error(format!(
+                        "git pull failed: {}",
+                        output.stderr
+                    )))
+                }
+            }
+            Err(e) => Ok(ToolResult::error(e)),
+        }
+    }
+
+    fn config(&self) -> &ToolConfig {
+        &self.config
+    }
+}
+
+// ============================================================================
+// Git Push Tool
+// ============================================================================
+
+/// Push changes
+pub struct GitPushTool {
+    config: ToolConfig,
+}
+
+impl GitPushTool {
+    pub fn new() -> Self {
+        let parameters = create_schema(
+            serde_json::json!({
+                "path": {
+                    "type": "string",
+                    "description": "Repository path",
+                    "default": "."
+                },
+                "remote": {
+                    "type": "string",
+                    "description": "Remote name",
+                    "default": "origin"
+                },
+                "branch": {
+                    "type": "string",
+                    "description": "Branch to push"
+                },
+                "set_upstream": {
+                    "type": "boolean",
+                    "description": "Set upstream tracking",
+                    "default": false
+                },
+                "tags": {
+                    "type": "boolean",
+                    "description": "Push tags",
+                    "default": false
+                }
+            }),
+            vec![],
+        );
+
+        Self {
+            config: tool_config_with_timeout(
+                "git_push",
+                "Update remote refs along with associated objects.",
+                parameters,
+                120,
+            ),
+        }
+    }
+}
+
+impl Default for GitPushTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for GitPushTool {
+    async fn execute(&self, input: ToolInput) -> AofResult<ToolResult> {
+        let path: String = input.get_arg("path").unwrap_or_else(|_| ".".to_string());
+        let remote: String = input.get_arg("remote").unwrap_or_else(|_| "origin".to_string());
+        let branch: Option<String> = input.get_arg("branch").ok();
+        let set_upstream: bool = input.get_arg("set_upstream").unwrap_or(false);
+        let tags: bool = input.get_arg("tags").unwrap_or(false);
+
+        let mut args = vec!["push".to_string()];
+
+        if set_upstream {
+            args.push("-u".to_string());
+        }
+
+        if tags {
+            args.push("--tags".to_string());
+        }
+
+        args.push(remote.clone());
+
+        if let Some(ref b) = branch {
+            args.push(b.clone());
+        }
+
+        debug!(args = ?args, path = %path, "Executing git push");
+
+        let args_str: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        let result = execute_command("git", &args_str, Some(&path), 120).await;
+
+        match result {
+            Ok(output) => {
+                if output.success {
+                    Ok(ToolResult::success(serde_json::json!({
+                        "pushed": true,
+                        "remote": remote,
+                        "branch": branch,
+                        "output": format!("{}{}", output.stdout, output.stderr)
+                    })))
+                } else {
+                    Ok(ToolResult::error(format!(
+                        "git push failed: {}",
+                        output.stderr
+                    )))
+                }
+            }
+            Err(e) => Ok(ToolResult::error(e)),
+        }
+    }
+
+    fn config(&self) -> &ToolConfig {
+        &self.config
+    }
+}

--- a/aof/crates/aof-tools/src/tools/http.rs
+++ b/aof/crates/aof-tools/src/tools/http.rs
@@ -1,0 +1,199 @@
+//! HTTP Tool
+//!
+//! Tool for making HTTP requests.
+//!
+//! ## Features
+//!
+//! - GET, POST, PUT, DELETE, PATCH methods
+//! - Custom headers
+//! - JSON body support
+//! - Timeout control
+//!
+//! ## Prerequisites
+//!
+//! - Requires `http` feature flag
+//!
+//! ## MCP Alternative
+//!
+//! For MCP-based HTTP operations, use the fetch MCP server.
+
+use aof_core::{AofResult, Tool, ToolConfig, ToolInput, ToolResult};
+use async_trait::async_trait;
+use std::collections::HashMap;
+use tracing::debug;
+
+use super::common::{create_schema, tool_config_with_timeout};
+
+/// HTTP request tool
+pub struct HttpTool {
+    config: ToolConfig,
+}
+
+impl HttpTool {
+    pub fn new() -> Self {
+        let parameters = create_schema(
+            serde_json::json!({
+                "url": {
+                    "type": "string",
+                    "description": "URL to request"
+                },
+                "method": {
+                    "type": "string",
+                    "description": "HTTP method",
+                    "enum": ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD"],
+                    "default": "GET"
+                },
+                "headers": {
+                    "type": "object",
+                    "description": "Request headers",
+                    "additionalProperties": { "type": "string" }
+                },
+                "body": {
+                    "type": "string",
+                    "description": "Request body (for POST/PUT/PATCH)"
+                },
+                "json": {
+                    "type": "object",
+                    "description": "JSON body (alternative to body string)"
+                },
+                "timeout_secs": {
+                    "type": "integer",
+                    "description": "Request timeout in seconds",
+                    "default": 30
+                },
+                "follow_redirects": {
+                    "type": "boolean",
+                    "description": "Follow HTTP redirects",
+                    "default": true
+                }
+            }),
+            vec!["url"],
+        );
+
+        Self {
+            config: tool_config_with_timeout(
+                "http_request",
+                "Make an HTTP request. Returns status, headers, and body.",
+                parameters,
+                60,
+            ),
+        }
+    }
+}
+
+impl Default for HttpTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for HttpTool {
+    async fn execute(&self, input: ToolInput) -> AofResult<ToolResult> {
+        let url: String = input.get_arg("url")?;
+        let method: String = input.get_arg("method").unwrap_or_else(|_| "GET".to_string());
+        let headers: HashMap<String, String> = input.get_arg("headers").unwrap_or_default();
+        let body: Option<String> = input.get_arg("body").ok();
+        let json_body: Option<serde_json::Value> = input.get_arg("json").ok();
+        let timeout_secs: u64 = input.get_arg("timeout_secs").unwrap_or(30);
+        let follow_redirects: bool = input.get_arg("follow_redirects").unwrap_or(true);
+
+        debug!(url = %url, method = %method, "Making HTTP request");
+
+        // Build client
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(timeout_secs))
+            .redirect(if follow_redirects {
+                reqwest::redirect::Policy::default()
+            } else {
+                reqwest::redirect::Policy::none()
+            })
+            .build()
+            .map_err(|e| aof_core::AofError::tool(format!("Failed to create HTTP client: {}", e)))?;
+
+        // Build request
+        let mut request = match method.to_uppercase().as_str() {
+            "GET" => client.get(&url),
+            "POST" => client.post(&url),
+            "PUT" => client.put(&url),
+            "DELETE" => client.delete(&url),
+            "PATCH" => client.patch(&url),
+            "HEAD" => client.head(&url),
+            _ => return Ok(ToolResult::error(format!("Unsupported method: {}", method))),
+        };
+
+        // Add headers
+        for (key, value) in &headers {
+            request = request.header(key.as_str(), value.as_str());
+        }
+
+        // Add body
+        if let Some(json) = json_body {
+            request = request.json(&json);
+        } else if let Some(body_str) = body {
+            request = request.body(body_str);
+        }
+
+        // Execute request
+        let start = std::time::Instant::now();
+        let response = match request.send().await {
+            Ok(r) => r,
+            Err(e) => {
+                return Ok(ToolResult::error(format!("HTTP request failed: {}", e)));
+            }
+        };
+        let elapsed = start.elapsed().as_millis() as u64;
+
+        let status = response.status().as_u16();
+        let status_text = response.status().canonical_reason().unwrap_or("Unknown");
+
+        // Get response headers
+        let resp_headers: HashMap<String, String> = response
+            .headers()
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_str().unwrap_or("").to_string()))
+            .collect();
+
+        // Get response body
+        let body_text = match response.text().await {
+            Ok(t) => t,
+            Err(e) => {
+                return Ok(ToolResult::error(format!("Failed to read response body: {}", e)));
+            }
+        };
+
+        // Try to parse as JSON
+        let body_json: Option<serde_json::Value> = serde_json::from_str(&body_text).ok();
+
+        Ok(ToolResult::success(serde_json::json!({
+            "status": status,
+            "status_text": status_text,
+            "headers": resp_headers,
+            "body": if body_json.is_some() { body_json } else { Some(serde_json::json!(body_text)) },
+            "elapsed_ms": elapsed,
+            "url": url
+        })).with_execution_time(elapsed))
+    }
+
+    fn config(&self) -> &ToolConfig {
+        &self.config
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_http_get() {
+        let tool = HttpTool::new();
+        let input = ToolInput::new(serde_json::json!({
+            "url": "https://httpbin.org/get",
+            "timeout_secs": 10
+        }));
+
+        let result = tool.execute(input).await.unwrap();
+        assert!(result.success);
+        assert_eq!(result.data["status"], 200);
+    }
+}

--- a/aof/crates/aof-tools/src/tools/kubectl.rs
+++ b/aof/crates/aof-tools/src/tools/kubectl.rs
@@ -1,0 +1,768 @@
+//! Kubectl Tools
+//!
+//! Tools for Kubernetes operations via kubectl CLI.
+//!
+//! ## Available Tools
+//!
+//! - `kubectl_get` - Get resources (pods, deployments, services, etc.)
+//! - `kubectl_apply` - Apply manifests
+//! - `kubectl_delete` - Delete resources
+//! - `kubectl_logs` - Get pod logs
+//! - `kubectl_exec` - Execute commands in containers
+//! - `kubectl_describe` - Describe resources
+//!
+//! ## Prerequisites
+//!
+//! - kubectl must be installed and in PATH
+//! - Valid kubeconfig with cluster access
+//!
+//! ## MCP Alternative
+//!
+//! Use kubectl-ai MCP server for enhanced K8s operations:
+//! ```yaml
+//! mcp_servers:
+//!   - name: kubectl-ai
+//!     transport: stdio
+//!     command: kubectl-ai
+//!     args: ["--mcp-server"]
+//! ```
+
+use aof_core::{AofResult, Tool, ToolConfig, ToolInput, ToolResult};
+use async_trait::async_trait;
+use tracing::debug;
+
+use super::common::{execute_command, create_schema, tool_config_with_timeout};
+
+/// Collection of all kubectl tools
+pub struct KubectlTools;
+
+impl KubectlTools {
+    /// Get all kubectl tools
+    pub fn all() -> Vec<Box<dyn Tool>> {
+        vec![
+            Box::new(KubectlGetTool::new()),
+            Box::new(KubectlApplyTool::new()),
+            Box::new(KubectlDeleteTool::new()),
+            Box::new(KubectlLogsTool::new()),
+            Box::new(KubectlExecTool::new()),
+            Box::new(KubectlDescribeTool::new()),
+        ]
+    }
+
+    /// Check if kubectl is available
+    pub fn is_available() -> bool {
+        which::which("kubectl").is_ok()
+    }
+}
+
+// ============================================================================
+// Kubectl Get Tool
+// ============================================================================
+
+/// Get Kubernetes resources
+pub struct KubectlGetTool {
+    config: ToolConfig,
+}
+
+impl KubectlGetTool {
+    pub fn new() -> Self {
+        let parameters = create_schema(
+            serde_json::json!({
+                "resource": {
+                    "type": "string",
+                    "description": "Resource type (e.g., pods, deployments, services, nodes)"
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Resource name (optional, omit to list all)"
+                },
+                "namespace": {
+                    "type": "string",
+                    "description": "Kubernetes namespace (default: current context namespace)"
+                },
+                "all_namespaces": {
+                    "type": "boolean",
+                    "description": "Get resources from all namespaces",
+                    "default": false
+                },
+                "output": {
+                    "type": "string",
+                    "description": "Output format: json, yaml, wide, name",
+                    "enum": ["json", "yaml", "wide", "name"],
+                    "default": "json"
+                },
+                "selector": {
+                    "type": "string",
+                    "description": "Label selector (e.g., 'app=nginx,env=prod')"
+                },
+                "field_selector": {
+                    "type": "string",
+                    "description": "Field selector (e.g., 'status.phase=Running')"
+                }
+            }),
+            vec!["resource"],
+        );
+
+        Self {
+            config: tool_config_with_timeout(
+                "kubectl_get",
+                "Get Kubernetes resources. Returns resource details in specified format.",
+                parameters,
+                60,
+            ),
+        }
+    }
+}
+
+impl Default for KubectlGetTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for KubectlGetTool {
+    async fn execute(&self, input: ToolInput) -> AofResult<ToolResult> {
+        let resource: String = input.get_arg("resource")?;
+        let name: Option<String> = input.get_arg("name").ok();
+        let namespace: Option<String> = input.get_arg("namespace").ok();
+        let all_namespaces: bool = input.get_arg("all_namespaces").unwrap_or(false);
+        let output: String = input.get_arg("output").unwrap_or_else(|_| "json".to_string());
+        let selector: Option<String> = input.get_arg("selector").ok();
+        let field_selector: Option<String> = input.get_arg("field_selector").ok();
+
+        let mut args = vec!["get", &resource];
+
+        if let Some(ref n) = name {
+            args.push(n);
+        }
+
+        let ns_flag;
+        if all_namespaces {
+            args.push("-A");
+        } else if let Some(ref ns) = namespace {
+            ns_flag = format!("-n={}", ns);
+            args.push(&ns_flag);
+        }
+
+        let output_flag = format!("-o={}", output);
+        args.push(&output_flag);
+
+        let selector_flag;
+        if let Some(ref sel) = selector {
+            selector_flag = format!("-l={}", sel);
+            args.push(&selector_flag);
+        }
+
+        let field_flag;
+        if let Some(ref field) = field_selector {
+            field_flag = format!("--field-selector={}", field);
+            args.push(&field_flag);
+        }
+
+        debug!(args = ?args, "Executing kubectl get");
+
+        let args_str: Vec<&str> = args.iter().map(|s| s.as_ref()).collect();
+        let result = execute_command("kubectl", &args_str, None, 60).await;
+
+        match result {
+            Ok(output) => {
+                if output.success {
+                    // Try to parse JSON output
+                    let data = if output_flag == "-o=json" {
+                        serde_json::from_str(&output.stdout).unwrap_or_else(|_| {
+                            serde_json::json!({ "raw": output.stdout })
+                        })
+                    } else {
+                        serde_json::json!({ "output": output.stdout })
+                    };
+
+                    Ok(ToolResult::success(serde_json::json!({
+                        "data": data,
+                        "resource": resource,
+                        "namespace": namespace
+                    })))
+                } else {
+                    Ok(ToolResult::error(format!(
+                        "kubectl get failed: {}",
+                        output.stderr
+                    )))
+                }
+            }
+            Err(e) => Ok(ToolResult::error(e)),
+        }
+    }
+
+    fn config(&self) -> &ToolConfig {
+        &self.config
+    }
+}
+
+// ============================================================================
+// Kubectl Apply Tool
+// ============================================================================
+
+/// Apply Kubernetes manifests
+pub struct KubectlApplyTool {
+    config: ToolConfig,
+}
+
+impl KubectlApplyTool {
+    pub fn new() -> Self {
+        let parameters = create_schema(
+            serde_json::json!({
+                "manifest": {
+                    "type": "string",
+                    "description": "YAML manifest content to apply"
+                },
+                "file": {
+                    "type": "string",
+                    "description": "Path to manifest file (alternative to inline manifest)"
+                },
+                "namespace": {
+                    "type": "string",
+                    "description": "Kubernetes namespace"
+                },
+                "dry_run": {
+                    "type": "string",
+                    "description": "Dry run mode: none, client, server",
+                    "enum": ["none", "client", "server"],
+                    "default": "none"
+                },
+                "force": {
+                    "type": "boolean",
+                    "description": "Force apply (delete and recreate)",
+                    "default": false
+                }
+            }),
+            vec![],
+        );
+
+        Self {
+            config: tool_config_with_timeout(
+                "kubectl_apply",
+                "Apply a Kubernetes manifest. Creates or updates resources.",
+                parameters,
+                120,
+            ),
+        }
+    }
+}
+
+impl Default for KubectlApplyTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for KubectlApplyTool {
+    async fn execute(&self, input: ToolInput) -> AofResult<ToolResult> {
+        let manifest: Option<String> = input.get_arg("manifest").ok();
+        let file: Option<String> = input.get_arg("file").ok();
+        let namespace: Option<String> = input.get_arg("namespace").ok();
+        let dry_run: String = input.get_arg("dry_run").unwrap_or_else(|_| "none".to_string());
+        let force: bool = input.get_arg("force").unwrap_or(false);
+
+        if manifest.is_none() && file.is_none() {
+            return Ok(ToolResult::error("Either 'manifest' or 'file' is required"));
+        }
+
+        let mut args = vec!["apply".to_string()];
+
+        if let Some(ref f) = file {
+            args.push(format!("-f={}", f));
+        } else if let Some(ref m) = manifest {
+            // Write manifest to temp file
+            let temp_path = "/tmp/kubectl-apply-manifest.yaml";
+            if let Err(e) = tokio::fs::write(temp_path, m).await {
+                return Ok(ToolResult::error(format!("Failed to write temp manifest: {}", e)));
+            }
+            args.push(format!("-f={}", temp_path));
+        }
+
+        if let Some(ref ns) = namespace {
+            args.push(format!("-n={}", ns));
+        }
+
+        if dry_run != "none" {
+            args.push(format!("--dry-run={}", dry_run));
+        }
+
+        if force {
+            args.push("--force".to_string());
+        }
+
+        args.push("-o=json".to_string());
+
+        debug!(args = ?args, "Executing kubectl apply");
+
+        let args_str: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        let result = execute_command("kubectl", &args_str, None, 120).await;
+
+        match result {
+            Ok(output) => {
+                if output.success {
+                    let data = serde_json::from_str(&output.stdout).unwrap_or_else(|_| {
+                        serde_json::json!({ "output": output.stdout })
+                    });
+                    Ok(ToolResult::success(serde_json::json!({
+                        "applied": data,
+                        "dry_run": dry_run != "none"
+                    })))
+                } else {
+                    Ok(ToolResult::error(format!(
+                        "kubectl apply failed: {}",
+                        output.stderr
+                    )))
+                }
+            }
+            Err(e) => Ok(ToolResult::error(e)),
+        }
+    }
+
+    fn config(&self) -> &ToolConfig {
+        &self.config
+    }
+}
+
+// ============================================================================
+// Kubectl Delete Tool
+// ============================================================================
+
+/// Delete Kubernetes resources
+pub struct KubectlDeleteTool {
+    config: ToolConfig,
+}
+
+impl KubectlDeleteTool {
+    pub fn new() -> Self {
+        let parameters = create_schema(
+            serde_json::json!({
+                "resource": {
+                    "type": "string",
+                    "description": "Resource type (e.g., pod, deployment, service)"
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Resource name"
+                },
+                "namespace": {
+                    "type": "string",
+                    "description": "Kubernetes namespace"
+                },
+                "selector": {
+                    "type": "string",
+                    "description": "Label selector for bulk delete"
+                },
+                "force": {
+                    "type": "boolean",
+                    "description": "Force delete (immediate)",
+                    "default": false
+                },
+                "grace_period": {
+                    "type": "integer",
+                    "description": "Grace period in seconds",
+                    "default": 30
+                }
+            }),
+            vec!["resource"],
+        );
+
+        Self {
+            config: tool_config_with_timeout(
+                "kubectl_delete",
+                "Delete Kubernetes resources.",
+                parameters,
+                120,
+            ),
+        }
+    }
+}
+
+impl Default for KubectlDeleteTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for KubectlDeleteTool {
+    async fn execute(&self, input: ToolInput) -> AofResult<ToolResult> {
+        let resource: String = input.get_arg("resource")?;
+        let name: Option<String> = input.get_arg("name").ok();
+        let namespace: Option<String> = input.get_arg("namespace").ok();
+        let selector: Option<String> = input.get_arg("selector").ok();
+        let force: bool = input.get_arg("force").unwrap_or(false);
+        let grace_period: i32 = input.get_arg("grace_period").unwrap_or(30);
+
+        if name.is_none() && selector.is_none() {
+            return Ok(ToolResult::error("Either 'name' or 'selector' is required"));
+        }
+
+        let mut args = vec!["delete".to_string(), resource.clone()];
+
+        if let Some(ref n) = name {
+            args.push(n.clone());
+        }
+
+        if let Some(ref ns) = namespace {
+            args.push(format!("-n={}", ns));
+        }
+
+        if let Some(ref sel) = selector {
+            args.push(format!("-l={}", sel));
+        }
+
+        if force {
+            args.push("--force".to_string());
+            args.push("--grace-period=0".to_string());
+        } else {
+            args.push(format!("--grace-period={}", grace_period));
+        }
+
+        debug!(args = ?args, "Executing kubectl delete");
+
+        let args_str: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        let result = execute_command("kubectl", &args_str, None, 120).await;
+
+        match result {
+            Ok(output) => {
+                if output.success {
+                    Ok(ToolResult::success(serde_json::json!({
+                        "deleted": true,
+                        "resource": resource,
+                        "name": name,
+                        "output": output.stdout
+                    })))
+                } else {
+                    Ok(ToolResult::error(format!(
+                        "kubectl delete failed: {}",
+                        output.stderr
+                    )))
+                }
+            }
+            Err(e) => Ok(ToolResult::error(e)),
+        }
+    }
+
+    fn config(&self) -> &ToolConfig {
+        &self.config
+    }
+}
+
+// ============================================================================
+// Kubectl Logs Tool
+// ============================================================================
+
+/// Get pod logs
+pub struct KubectlLogsTool {
+    config: ToolConfig,
+}
+
+impl KubectlLogsTool {
+    pub fn new() -> Self {
+        let parameters = create_schema(
+            serde_json::json!({
+                "pod": {
+                    "type": "string",
+                    "description": "Pod name"
+                },
+                "namespace": {
+                    "type": "string",
+                    "description": "Kubernetes namespace"
+                },
+                "container": {
+                    "type": "string",
+                    "description": "Container name (for multi-container pods)"
+                },
+                "tail": {
+                    "type": "integer",
+                    "description": "Number of lines from the end",
+                    "default": 100
+                },
+                "since": {
+                    "type": "string",
+                    "description": "Show logs since duration (e.g., '5m', '1h')"
+                },
+                "previous": {
+                    "type": "boolean",
+                    "description": "Get logs from previous container instance",
+                    "default": false
+                },
+                "timestamps": {
+                    "type": "boolean",
+                    "description": "Include timestamps",
+                    "default": false
+                }
+            }),
+            vec!["pod"],
+        );
+
+        Self {
+            config: tool_config_with_timeout(
+                "kubectl_logs",
+                "Get logs from a Kubernetes pod.",
+                parameters,
+                60,
+            ),
+        }
+    }
+}
+
+impl Default for KubectlLogsTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for KubectlLogsTool {
+    async fn execute(&self, input: ToolInput) -> AofResult<ToolResult> {
+        let pod: String = input.get_arg("pod")?;
+        let namespace: Option<String> = input.get_arg("namespace").ok();
+        let container: Option<String> = input.get_arg("container").ok();
+        let tail: i32 = input.get_arg("tail").unwrap_or(100);
+        let since: Option<String> = input.get_arg("since").ok();
+        let previous: bool = input.get_arg("previous").unwrap_or(false);
+        let timestamps: bool = input.get_arg("timestamps").unwrap_or(false);
+
+        let mut args = vec!["logs".to_string(), pod.clone()];
+
+        if let Some(ref ns) = namespace {
+            args.push(format!("-n={}", ns));
+        }
+
+        if let Some(ref c) = container {
+            args.push(format!("-c={}", c));
+        }
+
+        args.push(format!("--tail={}", tail));
+
+        if let Some(ref s) = since {
+            args.push(format!("--since={}", s));
+        }
+
+        if previous {
+            args.push("--previous".to_string());
+        }
+
+        if timestamps {
+            args.push("--timestamps".to_string());
+        }
+
+        debug!(args = ?args, "Executing kubectl logs");
+
+        let args_str: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        let result = execute_command("kubectl", &args_str, None, 60).await;
+
+        match result {
+            Ok(output) => {
+                if output.success {
+                    Ok(ToolResult::success(serde_json::json!({
+                        "logs": output.stdout,
+                        "pod": pod,
+                        "container": container,
+                        "lines": output.stdout.lines().count()
+                    })))
+                } else {
+                    Ok(ToolResult::error(format!(
+                        "kubectl logs failed: {}",
+                        output.stderr
+                    )))
+                }
+            }
+            Err(e) => Ok(ToolResult::error(e)),
+        }
+    }
+
+    fn config(&self) -> &ToolConfig {
+        &self.config
+    }
+}
+
+// ============================================================================
+// Kubectl Exec Tool
+// ============================================================================
+
+/// Execute commands in containers
+pub struct KubectlExecTool {
+    config: ToolConfig,
+}
+
+impl KubectlExecTool {
+    pub fn new() -> Self {
+        let parameters = create_schema(
+            serde_json::json!({
+                "pod": {
+                    "type": "string",
+                    "description": "Pod name"
+                },
+                "command": {
+                    "type": "string",
+                    "description": "Command to execute in the container"
+                },
+                "namespace": {
+                    "type": "string",
+                    "description": "Kubernetes namespace"
+                },
+                "container": {
+                    "type": "string",
+                    "description": "Container name (for multi-container pods)"
+                }
+            }),
+            vec!["pod", "command"],
+        );
+
+        Self {
+            config: tool_config_with_timeout(
+                "kubectl_exec",
+                "Execute a command inside a Kubernetes pod container.",
+                parameters,
+                120,
+            ),
+        }
+    }
+}
+
+impl Default for KubectlExecTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for KubectlExecTool {
+    async fn execute(&self, input: ToolInput) -> AofResult<ToolResult> {
+        let pod: String = input.get_arg("pod")?;
+        let command: String = input.get_arg("command")?;
+        let namespace: Option<String> = input.get_arg("namespace").ok();
+        let container: Option<String> = input.get_arg("container").ok();
+
+        let mut args = vec!["exec".to_string(), pod.clone()];
+
+        if let Some(ref ns) = namespace {
+            args.push(format!("-n={}", ns));
+        }
+
+        if let Some(ref c) = container {
+            args.push(format!("-c={}", c));
+        }
+
+        args.push("--".to_string());
+        args.push("sh".to_string());
+        args.push("-c".to_string());
+        args.push(command.clone());
+
+        debug!(args = ?args, "Executing kubectl exec");
+
+        let args_str: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        let result = execute_command("kubectl", &args_str, None, 120).await;
+
+        match result {
+            Ok(output) => {
+                Ok(ToolResult::success(serde_json::json!({
+                    "stdout": output.stdout,
+                    "stderr": output.stderr,
+                    "exit_code": output.exit_code,
+                    "success": output.success,
+                    "pod": pod,
+                    "command": command
+                })))
+            }
+            Err(e) => Ok(ToolResult::error(e)),
+        }
+    }
+
+    fn config(&self) -> &ToolConfig {
+        &self.config
+    }
+}
+
+// ============================================================================
+// Kubectl Describe Tool
+// ============================================================================
+
+/// Describe Kubernetes resources
+pub struct KubectlDescribeTool {
+    config: ToolConfig,
+}
+
+impl KubectlDescribeTool {
+    pub fn new() -> Self {
+        let parameters = create_schema(
+            serde_json::json!({
+                "resource": {
+                    "type": "string",
+                    "description": "Resource type (e.g., pod, deployment, service)"
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Resource name"
+                },
+                "namespace": {
+                    "type": "string",
+                    "description": "Kubernetes namespace"
+                }
+            }),
+            vec!["resource", "name"],
+        );
+
+        Self {
+            config: tool_config_with_timeout(
+                "kubectl_describe",
+                "Get detailed description of a Kubernetes resource.",
+                parameters,
+                60,
+            ),
+        }
+    }
+}
+
+impl Default for KubectlDescribeTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for KubectlDescribeTool {
+    async fn execute(&self, input: ToolInput) -> AofResult<ToolResult> {
+        let resource: String = input.get_arg("resource")?;
+        let name: String = input.get_arg("name")?;
+        let namespace: Option<String> = input.get_arg("namespace").ok();
+
+        let mut args = vec!["describe".to_string(), resource.clone(), name.clone()];
+
+        if let Some(ref ns) = namespace {
+            args.push(format!("-n={}", ns));
+        }
+
+        debug!(args = ?args, "Executing kubectl describe");
+
+        let args_str: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        let result = execute_command("kubectl", &args_str, None, 60).await;
+
+        match result {
+            Ok(output) => {
+                if output.success {
+                    Ok(ToolResult::success(serde_json::json!({
+                        "description": output.stdout,
+                        "resource": resource,
+                        "name": name
+                    })))
+                } else {
+                    Ok(ToolResult::error(format!(
+                        "kubectl describe failed: {}",
+                        output.stderr
+                    )))
+                }
+            }
+            Err(e) => Ok(ToolResult::error(e)),
+        }
+    }
+
+    fn config(&self) -> &ToolConfig {
+        &self.config
+    }
+}

--- a/aof/crates/aof-tools/src/tools/mod.rs
+++ b/aof/crates/aof-tools/src/tools/mod.rs
@@ -1,0 +1,132 @@
+//! Tool implementations
+//!
+//! Each tool category is in its own module and can be enabled/disabled via feature flags.
+
+#[cfg(feature = "file")]
+pub mod file;
+
+#[cfg(feature = "shell")]
+pub mod shell;
+
+#[cfg(feature = "kubectl")]
+pub mod kubectl;
+
+#[cfg(feature = "docker")]
+pub mod docker;
+
+#[cfg(feature = "git")]
+pub mod git;
+
+#[cfg(feature = "terraform")]
+pub mod terraform;
+
+#[cfg(feature = "http")]
+pub mod http;
+
+#[cfg(feature = "observability")]
+pub mod observability;
+
+/// Common utilities for tool implementations
+pub mod common {
+    use aof_core::ToolConfig;
+    use std::collections::HashMap;
+
+    /// Create a standard JSON schema for a tool with required and optional parameters
+    pub fn create_schema(
+        properties: serde_json::Value,
+        required: Vec<&str>,
+    ) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": properties,
+            "required": required
+        })
+    }
+
+    /// Create a basic tool config
+    pub fn tool_config(
+        name: &str,
+        description: &str,
+        parameters: serde_json::Value,
+    ) -> ToolConfig {
+        ToolConfig {
+            name: name.to_string(),
+            description: description.to_string(),
+            parameters,
+            tool_type: aof_core::ToolType::Custom,
+            timeout_secs: 30,
+            extra: HashMap::new(),
+        }
+    }
+
+    /// Create a tool config with custom timeout
+    pub fn tool_config_with_timeout(
+        name: &str,
+        description: &str,
+        parameters: serde_json::Value,
+        timeout_secs: u64,
+    ) -> ToolConfig {
+        ToolConfig {
+            name: name.to_string(),
+            description: description.to_string(),
+            parameters,
+            tool_type: aof_core::ToolType::Custom,
+            timeout_secs,
+            extra: HashMap::new(),
+        }
+    }
+
+    /// Execute a command and return structured output
+    pub async fn execute_command(
+        program: &str,
+        args: &[&str],
+        working_dir: Option<&str>,
+        timeout_secs: u64,
+    ) -> Result<CommandOutput, String> {
+        use tokio::process::Command;
+        use std::time::Duration;
+
+        let mut cmd = Command::new(program);
+        cmd.args(args);
+
+        if let Some(dir) = working_dir {
+            cmd.current_dir(dir);
+        }
+
+        // Capture output
+        cmd.stdout(std::process::Stdio::piped());
+        cmd.stderr(std::process::Stdio::piped());
+
+        let child = cmd.spawn().map_err(|e| format!("Failed to spawn {}: {}", program, e))?;
+
+        let output = tokio::time::timeout(
+            Duration::from_secs(timeout_secs),
+            child.wait_with_output(),
+        )
+        .await
+        .map_err(|_| format!("Command timed out after {}s", timeout_secs))?
+        .map_err(|e| format!("Command failed: {}", e))?;
+
+        Ok(CommandOutput {
+            exit_code: output.status.code().unwrap_or(-1),
+            stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+            success: output.status.success(),
+        })
+    }
+
+    /// Command execution output
+    #[derive(Debug, Clone, serde::Serialize)]
+    pub struct CommandOutput {
+        pub exit_code: i32,
+        pub stdout: String,
+        pub stderr: String,
+        pub success: bool,
+    }
+
+    impl CommandOutput {
+        pub fn to_json(&self) -> serde_json::Value {
+            serde_json::to_value(self).unwrap_or_default()
+        }
+    }
+}

--- a/aof/crates/aof-tools/src/tools/observability.rs
+++ b/aof/crates/aof-tools/src/tools/observability.rs
@@ -1,0 +1,616 @@
+//! Observability Tools
+//!
+//! Tools for querying and interacting with observability platforms.
+//!
+//! ## Available Tools
+//!
+//! - `prometheus_query` - Query Prometheus metrics
+//! - `loki_query` - Query Loki logs
+//! - `elasticsearch_query` - Query Elasticsearch/OpenSearch
+//! - `victoriametrics_query` - Query VictoriaMetrics
+//!
+//! ## Prerequisites
+//!
+//! - Requires `observability` feature flag
+//! - Valid endpoint URLs and credentials
+//!
+//! ## MCP Alternative
+//!
+//! For MCP-based observability, use dedicated MCP servers for each platform.
+
+use aof_core::{AofResult, Tool, ToolConfig, ToolInput, ToolResult};
+use async_trait::async_trait;
+use std::collections::HashMap;
+use tracing::debug;
+
+use super::common::{create_schema, tool_config_with_timeout};
+
+/// Collection of all observability tools
+pub struct ObservabilityTools;
+
+impl ObservabilityTools {
+    /// Get all observability tools
+    pub fn all() -> Vec<Box<dyn Tool>> {
+        vec![
+            Box::new(PrometheusQueryTool::new()),
+            Box::new(LokiQueryTool::new()),
+            Box::new(ElasticsearchQueryTool::new()),
+            Box::new(VictoriaMetricsQueryTool::new()),
+        ]
+    }
+}
+
+// ============================================================================
+// Prometheus Query Tool
+// ============================================================================
+
+/// Query Prometheus metrics
+pub struct PrometheusQueryTool {
+    config: ToolConfig,
+}
+
+impl PrometheusQueryTool {
+    pub fn new() -> Self {
+        let parameters = create_schema(
+            serde_json::json!({
+                "endpoint": {
+                    "type": "string",
+                    "description": "Prometheus server URL (e.g., http://prometheus:9090)"
+                },
+                "query": {
+                    "type": "string",
+                    "description": "PromQL query"
+                },
+                "time": {
+                    "type": "string",
+                    "description": "Evaluation timestamp (RFC3339 or Unix timestamp)"
+                },
+                "start": {
+                    "type": "string",
+                    "description": "Range query start time"
+                },
+                "end": {
+                    "type": "string",
+                    "description": "Range query end time"
+                },
+                "step": {
+                    "type": "string",
+                    "description": "Range query step (e.g., '15s', '1m')",
+                    "default": "15s"
+                },
+                "timeout": {
+                    "type": "string",
+                    "description": "Query timeout",
+                    "default": "30s"
+                }
+            }),
+            vec!["endpoint", "query"],
+        );
+
+        Self {
+            config: tool_config_with_timeout(
+                "prometheus_query",
+                "Query Prometheus metrics using PromQL. Supports instant and range queries.",
+                parameters,
+                60,
+            ),
+        }
+    }
+}
+
+impl Default for PrometheusQueryTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for PrometheusQueryTool {
+    async fn execute(&self, input: ToolInput) -> AofResult<ToolResult> {
+        let endpoint: String = input.get_arg("endpoint")?;
+        let query: String = input.get_arg("query")?;
+        let time: Option<String> = input.get_arg("time").ok();
+        let start: Option<String> = input.get_arg("start").ok();
+        let end: Option<String> = input.get_arg("end").ok();
+        let step: String = input.get_arg("step").unwrap_or_else(|_| "15s".to_string());
+        let timeout: String = input.get_arg("timeout").unwrap_or_else(|_| "30s".to_string());
+
+        debug!(endpoint = %endpoint, query = %query, "Querying Prometheus");
+
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(60))
+            .build()
+            .map_err(|e| aof_core::AofError::tool(format!("Failed to create HTTP client: {}", e)))?;
+
+        // Determine if range query or instant query
+        let (url, params) = if start.is_some() && end.is_some() {
+            let url = format!("{}/api/v1/query_range", endpoint.trim_end_matches('/'));
+            let mut params = vec![
+                ("query", query.clone()),
+                ("start", start.unwrap()),
+                ("end", end.unwrap()),
+                ("step", step),
+                ("timeout", timeout),
+            ];
+            (url, params)
+        } else {
+            let url = format!("{}/api/v1/query", endpoint.trim_end_matches('/'));
+            let mut params = vec![
+                ("query", query.clone()),
+                ("timeout", timeout),
+            ];
+            if let Some(t) = time {
+                params.push(("time", t));
+            }
+            (url, params)
+        };
+
+        let response = match client.get(&url).query(&params).send().await {
+            Ok(r) => r,
+            Err(e) => {
+                return Ok(ToolResult::error(format!("Prometheus query failed: {}", e)));
+            }
+        };
+
+        let status = response.status().as_u16();
+        let body: serde_json::Value = match response.json().await {
+            Ok(b) => b,
+            Err(e) => {
+                return Ok(ToolResult::error(format!("Failed to parse response: {}", e)));
+            }
+        };
+
+        if status != 200 {
+            return Ok(ToolResult::error(format!(
+                "Prometheus returned status {}: {:?}",
+                status,
+                body.get("error")
+            )));
+        }
+
+        Ok(ToolResult::success(serde_json::json!({
+            "status": body.get("status"),
+            "data": body.get("data"),
+            "query": query
+        })))
+    }
+
+    fn config(&self) -> &ToolConfig {
+        &self.config
+    }
+}
+
+// ============================================================================
+// Loki Query Tool
+// ============================================================================
+
+/// Query Loki logs
+pub struct LokiQueryTool {
+    config: ToolConfig,
+}
+
+impl LokiQueryTool {
+    pub fn new() -> Self {
+        let parameters = create_schema(
+            serde_json::json!({
+                "endpoint": {
+                    "type": "string",
+                    "description": "Loki server URL (e.g., http://loki:3100)"
+                },
+                "query": {
+                    "type": "string",
+                    "description": "LogQL query"
+                },
+                "start": {
+                    "type": "string",
+                    "description": "Start time (RFC3339 or Unix nanoseconds)"
+                },
+                "end": {
+                    "type": "string",
+                    "description": "End time (RFC3339 or Unix nanoseconds)"
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum number of entries",
+                    "default": 100
+                },
+                "direction": {
+                    "type": "string",
+                    "description": "Query direction: forward or backward",
+                    "enum": ["forward", "backward"],
+                    "default": "backward"
+                }
+            }),
+            vec!["endpoint", "query"],
+        );
+
+        Self {
+            config: tool_config_with_timeout(
+                "loki_query",
+                "Query Loki logs using LogQL. Returns log entries matching the query.",
+                parameters,
+                60,
+            ),
+        }
+    }
+}
+
+impl Default for LokiQueryTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for LokiQueryTool {
+    async fn execute(&self, input: ToolInput) -> AofResult<ToolResult> {
+        let endpoint: String = input.get_arg("endpoint")?;
+        let query: String = input.get_arg("query")?;
+        let start: Option<String> = input.get_arg("start").ok();
+        let end: Option<String> = input.get_arg("end").ok();
+        let limit: i32 = input.get_arg("limit").unwrap_or(100);
+        let direction: String = input.get_arg("direction").unwrap_or_else(|_| "backward".to_string());
+
+        debug!(endpoint = %endpoint, query = %query, "Querying Loki");
+
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(60))
+            .build()
+            .map_err(|e| aof_core::AofError::tool(format!("Failed to create HTTP client: {}", e)))?;
+
+        let url = format!("{}/loki/api/v1/query_range", endpoint.trim_end_matches('/'));
+
+        let mut params = vec![
+            ("query", query.clone()),
+            ("limit", limit.to_string()),
+            ("direction", direction),
+        ];
+
+        if let Some(s) = start {
+            params.push(("start", s));
+        }
+        if let Some(e) = end {
+            params.push(("end", e));
+        }
+
+        let response = match client.get(&url).query(&params).send().await {
+            Ok(r) => r,
+            Err(e) => {
+                return Ok(ToolResult::error(format!("Loki query failed: {}", e)));
+            }
+        };
+
+        let status = response.status().as_u16();
+        let body: serde_json::Value = match response.json().await {
+            Ok(b) => b,
+            Err(e) => {
+                return Ok(ToolResult::error(format!("Failed to parse response: {}", e)));
+            }
+        };
+
+        if status != 200 {
+            return Ok(ToolResult::error(format!(
+                "Loki returned status {}: {:?}",
+                status,
+                body.get("message")
+            )));
+        }
+
+        // Extract log entries count
+        let result_count = body
+            .get("data")
+            .and_then(|d| d.get("result"))
+            .and_then(|r| r.as_array())
+            .map(|a| a.len())
+            .unwrap_or(0);
+
+        Ok(ToolResult::success(serde_json::json!({
+            "status": body.get("status"),
+            "data": body.get("data"),
+            "query": query,
+            "result_count": result_count
+        })))
+    }
+
+    fn config(&self) -> &ToolConfig {
+        &self.config
+    }
+}
+
+// ============================================================================
+// Elasticsearch Query Tool
+// ============================================================================
+
+/// Query Elasticsearch/OpenSearch
+pub struct ElasticsearchQueryTool {
+    config: ToolConfig,
+}
+
+impl ElasticsearchQueryTool {
+    pub fn new() -> Self {
+        let parameters = create_schema(
+            serde_json::json!({
+                "endpoint": {
+                    "type": "string",
+                    "description": "Elasticsearch/OpenSearch URL (e.g., http://elasticsearch:9200)"
+                },
+                "index": {
+                    "type": "string",
+                    "description": "Index name or pattern (e.g., 'logs-*')"
+                },
+                "query": {
+                    "type": "object",
+                    "description": "Elasticsearch query DSL"
+                },
+                "size": {
+                    "type": "integer",
+                    "description": "Number of results to return",
+                    "default": 10
+                },
+                "from": {
+                    "type": "integer",
+                    "description": "Starting offset",
+                    "default": 0
+                },
+                "sort": {
+                    "type": "array",
+                    "description": "Sort specification",
+                    "items": { "type": "object" }
+                },
+                "source": {
+                    "type": "array",
+                    "description": "Fields to include in response",
+                    "items": { "type": "string" }
+                },
+                "auth": {
+                    "type": "object",
+                    "description": "Authentication (username, password)",
+                    "properties": {
+                        "username": { "type": "string" },
+                        "password": { "type": "string" }
+                    }
+                }
+            }),
+            vec!["endpoint", "index"],
+        );
+
+        Self {
+            config: tool_config_with_timeout(
+                "elasticsearch_query",
+                "Query Elasticsearch or OpenSearch. Supports full Query DSL.",
+                parameters,
+                60,
+            ),
+        }
+    }
+}
+
+impl Default for ElasticsearchQueryTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for ElasticsearchQueryTool {
+    async fn execute(&self, input: ToolInput) -> AofResult<ToolResult> {
+        let endpoint: String = input.get_arg("endpoint")?;
+        let index: String = input.get_arg("index")?;
+        let query: Option<serde_json::Value> = input.get_arg("query").ok();
+        let size: i32 = input.get_arg("size").unwrap_or(10);
+        let from: i32 = input.get_arg("from").unwrap_or(0);
+        let sort: Option<Vec<serde_json::Value>> = input.get_arg("sort").ok();
+        let source: Option<Vec<String>> = input.get_arg("source").ok();
+        let auth: Option<HashMap<String, String>> = input.get_arg("auth").ok();
+
+        debug!(endpoint = %endpoint, index = %index, "Querying Elasticsearch");
+
+        let mut client_builder = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(60));
+
+        let client = client_builder
+            .build()
+            .map_err(|e| aof_core::AofError::tool(format!("Failed to create HTTP client: {}", e)))?;
+
+        let url = format!("{}/{}/_search", endpoint.trim_end_matches('/'), index);
+
+        // Build search body
+        let mut body = serde_json::json!({
+            "size": size,
+            "from": from
+        });
+
+        if let Some(q) = query {
+            body["query"] = q;
+        } else {
+            body["query"] = serde_json::json!({ "match_all": {} });
+        }
+
+        if let Some(s) = sort {
+            body["sort"] = serde_json::json!(s);
+        }
+
+        if let Some(src) = source {
+            body["_source"] = serde_json::json!(src);
+        }
+
+        let mut request = client.post(&url).json(&body);
+
+        if let Some(auth_info) = auth {
+            if let (Some(user), Some(pass)) = (auth_info.get("username"), auth_info.get("password")) {
+                request = request.basic_auth(user, Some(pass));
+            }
+        }
+
+        let response = match request.send().await {
+            Ok(r) => r,
+            Err(e) => {
+                return Ok(ToolResult::error(format!("Elasticsearch query failed: {}", e)));
+            }
+        };
+
+        let status = response.status().as_u16();
+        let resp_body: serde_json::Value = match response.json().await {
+            Ok(b) => b,
+            Err(e) => {
+                return Ok(ToolResult::error(format!("Failed to parse response: {}", e)));
+            }
+        };
+
+        if status >= 400 {
+            return Ok(ToolResult::error(format!(
+                "Elasticsearch returned status {}: {:?}",
+                status,
+                resp_body.get("error")
+            )));
+        }
+
+        let hits = resp_body
+            .get("hits")
+            .and_then(|h| h.get("total"))
+            .and_then(|t| t.get("value").or(Some(t)))
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0);
+
+        Ok(ToolResult::success(serde_json::json!({
+            "hits": resp_body.get("hits"),
+            "took": resp_body.get("took"),
+            "total_hits": hits,
+            "index": index
+        })))
+    }
+
+    fn config(&self) -> &ToolConfig {
+        &self.config
+    }
+}
+
+// ============================================================================
+// VictoriaMetrics Query Tool
+// ============================================================================
+
+/// Query VictoriaMetrics
+pub struct VictoriaMetricsQueryTool {
+    config: ToolConfig,
+}
+
+impl VictoriaMetricsQueryTool {
+    pub fn new() -> Self {
+        let parameters = create_schema(
+            serde_json::json!({
+                "endpoint": {
+                    "type": "string",
+                    "description": "VictoriaMetrics URL (e.g., http://victoriametrics:8428)"
+                },
+                "query": {
+                    "type": "string",
+                    "description": "MetricsQL query (PromQL compatible)"
+                },
+                "time": {
+                    "type": "string",
+                    "description": "Evaluation timestamp"
+                },
+                "start": {
+                    "type": "string",
+                    "description": "Range query start time"
+                },
+                "end": {
+                    "type": "string",
+                    "description": "Range query end time"
+                },
+                "step": {
+                    "type": "string",
+                    "description": "Range query step",
+                    "default": "15s"
+                }
+            }),
+            vec!["endpoint", "query"],
+        );
+
+        Self {
+            config: tool_config_with_timeout(
+                "victoriametrics_query",
+                "Query VictoriaMetrics using MetricsQL. Compatible with PromQL.",
+                parameters,
+                60,
+            ),
+        }
+    }
+}
+
+impl Default for VictoriaMetricsQueryTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for VictoriaMetricsQueryTool {
+    async fn execute(&self, input: ToolInput) -> AofResult<ToolResult> {
+        let endpoint: String = input.get_arg("endpoint")?;
+        let query: String = input.get_arg("query")?;
+        let time: Option<String> = input.get_arg("time").ok();
+        let start: Option<String> = input.get_arg("start").ok();
+        let end: Option<String> = input.get_arg("end").ok();
+        let step: String = input.get_arg("step").unwrap_or_else(|_| "15s".to_string());
+
+        debug!(endpoint = %endpoint, query = %query, "Querying VictoriaMetrics");
+
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(60))
+            .build()
+            .map_err(|e| aof_core::AofError::tool(format!("Failed to create HTTP client: {}", e)))?;
+
+        // VictoriaMetrics uses same API as Prometheus
+        let (url, params): (String, Vec<(&str, String)>) = if start.is_some() && end.is_some() {
+            let url = format!("{}/api/v1/query_range", endpoint.trim_end_matches('/'));
+            let params = vec![
+                ("query", query.clone()),
+                ("start", start.unwrap()),
+                ("end", end.unwrap()),
+                ("step", step),
+            ];
+            (url, params)
+        } else {
+            let url = format!("{}/api/v1/query", endpoint.trim_end_matches('/'));
+            let mut params = vec![("query", query.clone())];
+            if let Some(t) = time {
+                params.push(("time", t));
+            }
+            (url, params)
+        };
+
+        let response = match client.get(&url).query(&params).send().await {
+            Ok(r) => r,
+            Err(e) => {
+                return Ok(ToolResult::error(format!("VictoriaMetrics query failed: {}", e)));
+            }
+        };
+
+        let status = response.status().as_u16();
+        let body: serde_json::Value = match response.json().await {
+            Ok(b) => b,
+            Err(e) => {
+                return Ok(ToolResult::error(format!("Failed to parse response: {}", e)));
+            }
+        };
+
+        if status != 200 {
+            return Ok(ToolResult::error(format!(
+                "VictoriaMetrics returned status {}: {:?}",
+                status,
+                body.get("error")
+            )));
+        }
+
+        Ok(ToolResult::success(serde_json::json!({
+            "status": body.get("status"),
+            "data": body.get("data"),
+            "query": query
+        })))
+    }
+
+    fn config(&self) -> &ToolConfig {
+        &self.config
+    }
+}

--- a/aof/crates/aof-tools/src/tools/shell.rs
+++ b/aof/crates/aof-tools/src/tools/shell.rs
@@ -1,0 +1,294 @@
+//! Shell Tool
+//!
+//! Execute shell commands with safety controls and output capture.
+//!
+//! ## Security Considerations
+//!
+//! - Commands run in a subprocess with captured stdout/stderr
+//! - Timeout protection prevents runaway processes
+//! - Working directory can be specified for sandboxing
+//!
+//! ## MCP Alternative
+//!
+//! For MCP-based shell execution, you can use custom MCP servers
+//! or the built-in shell tool in stdio mode.
+
+use aof_core::{AofResult, Tool, ToolConfig, ToolInput, ToolResult};
+use async_trait::async_trait;
+use std::collections::HashMap;
+use tokio::process::Command;
+use tokio::time::{timeout, Duration};
+use tracing::{debug, warn};
+
+use super::common::tool_config_with_timeout;
+
+/// Shell command execution tool
+pub struct ShellTool {
+    config: ToolConfig,
+    /// Default shell to use
+    shell: String,
+    /// Allowed commands (empty = allow all)
+    allowed_commands: Vec<String>,
+    /// Blocked commands
+    blocked_commands: Vec<String>,
+}
+
+impl ShellTool {
+    /// Create a new shell tool with default settings
+    pub fn new() -> Self {
+        let parameters = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "command": {
+                    "type": "string",
+                    "description": "The shell command to execute"
+                },
+                "working_dir": {
+                    "type": "string",
+                    "description": "Working directory for command execution"
+                },
+                "timeout_secs": {
+                    "type": "integer",
+                    "description": "Command timeout in seconds (default: 60)",
+                    "default": 60
+                },
+                "env": {
+                    "type": "object",
+                    "description": "Additional environment variables",
+                    "additionalProperties": { "type": "string" }
+                }
+            },
+            "required": ["command"]
+        });
+
+        Self {
+            config: tool_config_with_timeout(
+                "shell",
+                "Execute a shell command. Returns stdout, stderr, and exit code.",
+                parameters,
+                120, // 2 minute max timeout
+            ),
+            shell: Self::detect_shell(),
+            allowed_commands: vec![],
+            blocked_commands: Self::default_blocked_commands(),
+        }
+    }
+
+    /// Create with custom allowed commands (whitelist mode)
+    pub fn with_allowed_commands(mut self, commands: Vec<String>) -> Self {
+        self.allowed_commands = commands;
+        self
+    }
+
+    /// Create with additional blocked commands
+    pub fn with_blocked_commands(mut self, commands: Vec<String>) -> Self {
+        self.blocked_commands.extend(commands);
+        self
+    }
+
+    /// Create with custom shell
+    pub fn with_shell(mut self, shell: String) -> Self {
+        self.shell = shell;
+        self
+    }
+
+    fn detect_shell() -> String {
+        std::env::var("SHELL").unwrap_or_else(|_| {
+            if cfg!(windows) {
+                "cmd".to_string()
+            } else {
+                "/bin/sh".to_string()
+            }
+        })
+    }
+
+    fn default_blocked_commands() -> Vec<String> {
+        vec![
+            // Dangerous system commands
+            "rm -rf /".to_string(),
+            "mkfs".to_string(),
+            "dd if=/dev".to_string(),
+            ":(){:|:&};:".to_string(), // Fork bomb
+            // Network attacks
+            "nc -l".to_string(),   // Netcat listener (could be used for reverse shell)
+        ]
+    }
+
+    fn is_command_allowed(&self, command: &str) -> Result<(), String> {
+        // Check blocked commands
+        for blocked in &self.blocked_commands {
+            if command.contains(blocked) {
+                return Err(format!("Command contains blocked pattern: {}", blocked));
+            }
+        }
+
+        // Check allowed commands if whitelist mode is enabled
+        if !self.allowed_commands.is_empty() {
+            let cmd_name = command.split_whitespace().next().unwrap_or("");
+            if !self.allowed_commands.iter().any(|a| cmd_name.starts_with(a)) {
+                return Err(format!("Command not in allowed list: {}", cmd_name));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl Default for ShellTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for ShellTool {
+    async fn execute(&self, input: ToolInput) -> AofResult<ToolResult> {
+        let command: String = input.get_arg("command")?;
+        let working_dir: Option<String> = input.get_arg("working_dir").ok();
+        let timeout_secs: u64 = input.get_arg("timeout_secs").unwrap_or(60);
+        let env_vars: HashMap<String, String> = input
+            .get_arg("env")
+            .unwrap_or_default();
+
+        // Security check
+        if let Err(e) = self.is_command_allowed(&command) {
+            warn!(command = %command, error = %e, "Command blocked by security policy");
+            return Ok(ToolResult::error(format!("Security policy violation: {}", e)));
+        }
+
+        debug!(command = %command, shell = %self.shell, "Executing shell command");
+
+        let mut cmd = if cfg!(windows) {
+            let mut c = Command::new("cmd");
+            c.args(["/C", &command]);
+            c
+        } else {
+            let mut c = Command::new(&self.shell);
+            c.args(["-c", &command]);
+            c
+        };
+
+        // Set working directory if specified
+        if let Some(dir) = &working_dir {
+            cmd.current_dir(dir);
+        }
+
+        // Add environment variables
+        for (key, value) in &env_vars {
+            cmd.env(key, value);
+        }
+
+        // Capture output
+        cmd.stdout(std::process::Stdio::piped());
+        cmd.stderr(std::process::Stdio::piped());
+
+        // Spawn and wait with timeout
+        let child = match cmd.spawn() {
+            Ok(c) => c,
+            Err(e) => {
+                return Ok(ToolResult::error(format!("Failed to spawn command: {}", e)));
+            }
+        };
+
+        let output = match timeout(Duration::from_secs(timeout_secs), child.wait_with_output()).await {
+            Ok(Ok(output)) => output,
+            Ok(Err(e)) => {
+                return Ok(ToolResult::error(format!("Command execution failed: {}", e)));
+            }
+            Err(_) => {
+                return Ok(ToolResult::error(format!(
+                    "Command timed out after {} seconds",
+                    timeout_secs
+                )));
+            }
+        };
+
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        let exit_code = output.status.code().unwrap_or(-1);
+        let success = output.status.success();
+
+        Ok(ToolResult::success(serde_json::json!({
+            "stdout": stdout,
+            "stderr": stderr,
+            "exit_code": exit_code,
+            "success": success,
+            "command": command
+        })))
+    }
+
+    fn config(&self) -> &ToolConfig {
+        &self.config
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_shell_echo() {
+        let tool = ShellTool::new();
+        let input = ToolInput::new(serde_json::json!({
+            "command": "echo 'Hello, World!'"
+        }));
+
+        let result = tool.execute(input).await.unwrap();
+        assert!(result.success);
+        assert!(result.data["stdout"].as_str().unwrap().contains("Hello, World!"));
+        assert_eq!(result.data["exit_code"], 0);
+    }
+
+    #[tokio::test]
+    async fn test_shell_exit_code() {
+        let tool = ShellTool::new();
+        let input = ToolInput::new(serde_json::json!({
+            "command": "exit 42"
+        }));
+
+        let result = tool.execute(input).await.unwrap();
+        assert!(result.success); // Tool succeeded, but command returned non-zero
+        assert_eq!(result.data["exit_code"], 42);
+        assert!(!result.data["success"].as_bool().unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_shell_blocked_command() {
+        let tool = ShellTool::new();
+        let input = ToolInput::new(serde_json::json!({
+            "command": "rm -rf /"
+        }));
+
+        let result = tool.execute(input).await.unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("Security policy"));
+    }
+
+    #[tokio::test]
+    async fn test_shell_with_env() {
+        let tool = ShellTool::new();
+        let input = ToolInput::new(serde_json::json!({
+            "command": "echo $MY_VAR",
+            "env": {
+                "MY_VAR": "test_value"
+            }
+        }));
+
+        let result = tool.execute(input).await.unwrap();
+        assert!(result.success);
+        assert!(result.data["stdout"].as_str().unwrap().contains("test_value"));
+    }
+
+    #[tokio::test]
+    async fn test_shell_timeout() {
+        let tool = ShellTool::new();
+        let input = ToolInput::new(serde_json::json!({
+            "command": "sleep 10",
+            "timeout_secs": 1
+        }));
+
+        let result = tool.execute(input).await.unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("timed out"));
+    }
+}

--- a/aof/crates/aof-tools/src/tools/terraform.rs
+++ b/aof/crates/aof-tools/src/tools/terraform.rs
@@ -1,0 +1,624 @@
+//! Terraform Tools
+//!
+//! Tools for Terraform Infrastructure as Code operations.
+//!
+//! ## Available Tools
+//!
+//! - `terraform_init` - Initialize Terraform working directory
+//! - `terraform_plan` - Create execution plan
+//! - `terraform_apply` - Apply changes
+//! - `terraform_destroy` - Destroy infrastructure
+//! - `terraform_output` - Get outputs
+//!
+//! ## Prerequisites
+//!
+//! - Terraform must be installed and in PATH
+//! - Valid provider credentials configured
+//!
+//! ## MCP Alternative
+//!
+//! For MCP-based Terraform operations, use a Terraform MCP server.
+
+use aof_core::{AofResult, Tool, ToolConfig, ToolInput, ToolResult};
+use async_trait::async_trait;
+use tracing::debug;
+
+use super::common::{execute_command, create_schema, tool_config_with_timeout};
+
+/// Collection of all Terraform tools
+pub struct TerraformTools;
+
+impl TerraformTools {
+    /// Get all Terraform tools
+    pub fn all() -> Vec<Box<dyn Tool>> {
+        vec![
+            Box::new(TerraformInitTool::new()),
+            Box::new(TerraformPlanTool::new()),
+            Box::new(TerraformApplyTool::new()),
+            Box::new(TerraformDestroyTool::new()),
+            Box::new(TerraformOutputTool::new()),
+        ]
+    }
+
+    /// Check if terraform is available
+    pub fn is_available() -> bool {
+        which::which("terraform").is_ok()
+    }
+}
+
+// ============================================================================
+// Terraform Init Tool
+// ============================================================================
+
+/// Initialize Terraform working directory
+pub struct TerraformInitTool {
+    config: ToolConfig,
+}
+
+impl TerraformInitTool {
+    pub fn new() -> Self {
+        let parameters = create_schema(
+            serde_json::json!({
+                "path": {
+                    "type": "string",
+                    "description": "Path to Terraform configuration",
+                    "default": "."
+                },
+                "upgrade": {
+                    "type": "boolean",
+                    "description": "Upgrade providers and modules",
+                    "default": false
+                },
+                "reconfigure": {
+                    "type": "boolean",
+                    "description": "Reconfigure backend",
+                    "default": false
+                },
+                "backend_config": {
+                    "type": "object",
+                    "description": "Backend configuration values",
+                    "additionalProperties": { "type": "string" }
+                }
+            }),
+            vec![],
+        );
+
+        Self {
+            config: tool_config_with_timeout(
+                "terraform_init",
+                "Initialize a Terraform working directory. Downloads providers and modules.",
+                parameters,
+                300,
+            ),
+        }
+    }
+}
+
+impl Default for TerraformInitTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for TerraformInitTool {
+    async fn execute(&self, input: ToolInput) -> AofResult<ToolResult> {
+        let path: String = input.get_arg("path").unwrap_or_else(|_| ".".to_string());
+        let upgrade: bool = input.get_arg("upgrade").unwrap_or(false);
+        let reconfigure: bool = input.get_arg("reconfigure").unwrap_or(false);
+        let backend_config: std::collections::HashMap<String, String> = input
+            .get_arg("backend_config")
+            .unwrap_or_default();
+
+        let mut args = vec!["init".to_string(), "-no-color".to_string()];
+
+        if upgrade {
+            args.push("-upgrade".to_string());
+        }
+
+        if reconfigure {
+            args.push("-reconfigure".to_string());
+        }
+
+        for (key, value) in &backend_config {
+            args.push(format!("-backend-config={}={}", key, value));
+        }
+
+        debug!(args = ?args, path = %path, "Executing terraform init");
+
+        let args_str: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        let result = execute_command("terraform", &args_str, Some(&path), 300).await;
+
+        match result {
+            Ok(output) => {
+                if output.success {
+                    Ok(ToolResult::success(serde_json::json!({
+                        "initialized": true,
+                        "output": output.stdout
+                    })))
+                } else {
+                    Ok(ToolResult::error(format!(
+                        "terraform init failed: {}",
+                        output.stderr
+                    )))
+                }
+            }
+            Err(e) => Ok(ToolResult::error(e)),
+        }
+    }
+
+    fn config(&self) -> &ToolConfig {
+        &self.config
+    }
+}
+
+// ============================================================================
+// Terraform Plan Tool
+// ============================================================================
+
+/// Create Terraform execution plan
+pub struct TerraformPlanTool {
+    config: ToolConfig,
+}
+
+impl TerraformPlanTool {
+    pub fn new() -> Self {
+        let parameters = create_schema(
+            serde_json::json!({
+                "path": {
+                    "type": "string",
+                    "description": "Path to Terraform configuration",
+                    "default": "."
+                },
+                "out": {
+                    "type": "string",
+                    "description": "Save plan to file"
+                },
+                "var": {
+                    "type": "object",
+                    "description": "Variable values",
+                    "additionalProperties": { "type": "string" }
+                },
+                "var_file": {
+                    "type": "string",
+                    "description": "Path to variable file"
+                },
+                "target": {
+                    "type": "array",
+                    "description": "Resource addresses to target",
+                    "items": { "type": "string" }
+                },
+                "destroy": {
+                    "type": "boolean",
+                    "description": "Create destroy plan",
+                    "default": false
+                }
+            }),
+            vec![],
+        );
+
+        Self {
+            config: tool_config_with_timeout(
+                "terraform_plan",
+                "Create a Terraform execution plan. Shows what changes will be made.",
+                parameters,
+                600,
+            ),
+        }
+    }
+}
+
+impl Default for TerraformPlanTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for TerraformPlanTool {
+    async fn execute(&self, input: ToolInput) -> AofResult<ToolResult> {
+        let path: String = input.get_arg("path").unwrap_or_else(|_| ".".to_string());
+        let out: Option<String> = input.get_arg("out").ok();
+        let var: std::collections::HashMap<String, String> = input.get_arg("var").unwrap_or_default();
+        let var_file: Option<String> = input.get_arg("var_file").ok();
+        let target: Vec<String> = input.get_arg("target").unwrap_or_default();
+        let destroy: bool = input.get_arg("destroy").unwrap_or(false);
+
+        let mut args = vec!["plan".to_string(), "-no-color".to_string()];
+
+        if let Some(ref o) = out {
+            args.push(format!("-out={}", o));
+        }
+
+        for (key, value) in &var {
+            args.push(format!("-var={}={}", key, value));
+        }
+
+        if let Some(ref vf) = var_file {
+            args.push(format!("-var-file={}", vf));
+        }
+
+        for t in &target {
+            args.push(format!("-target={}", t));
+        }
+
+        if destroy {
+            args.push("-destroy".to_string());
+        }
+
+        debug!(args = ?args, path = %path, "Executing terraform plan");
+
+        let args_str: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        let result = execute_command("terraform", &args_str, Some(&path), 600).await;
+
+        match result {
+            Ok(output) => {
+                if output.success {
+                    // Parse plan summary
+                    let stdout = &output.stdout;
+                    let has_changes = !stdout.contains("No changes.");
+
+                    Ok(ToolResult::success(serde_json::json!({
+                        "planned": true,
+                        "has_changes": has_changes,
+                        "plan_file": out,
+                        "output": stdout
+                    })))
+                } else {
+                    Ok(ToolResult::error(format!(
+                        "terraform plan failed: {}",
+                        output.stderr
+                    )))
+                }
+            }
+            Err(e) => Ok(ToolResult::error(e)),
+        }
+    }
+
+    fn config(&self) -> &ToolConfig {
+        &self.config
+    }
+}
+
+// ============================================================================
+// Terraform Apply Tool
+// ============================================================================
+
+/// Apply Terraform changes
+pub struct TerraformApplyTool {
+    config: ToolConfig,
+}
+
+impl TerraformApplyTool {
+    pub fn new() -> Self {
+        let parameters = create_schema(
+            serde_json::json!({
+                "path": {
+                    "type": "string",
+                    "description": "Path to Terraform configuration or plan file",
+                    "default": "."
+                },
+                "auto_approve": {
+                    "type": "boolean",
+                    "description": "Skip interactive approval",
+                    "default": true
+                },
+                "var": {
+                    "type": "object",
+                    "description": "Variable values",
+                    "additionalProperties": { "type": "string" }
+                },
+                "var_file": {
+                    "type": "string",
+                    "description": "Path to variable file"
+                },
+                "target": {
+                    "type": "array",
+                    "description": "Resource addresses to target",
+                    "items": { "type": "string" }
+                },
+                "plan_file": {
+                    "type": "string",
+                    "description": "Apply a saved plan file"
+                }
+            }),
+            vec![],
+        );
+
+        Self {
+            config: tool_config_with_timeout(
+                "terraform_apply",
+                "Apply Terraform changes to infrastructure.",
+                parameters,
+                1800, // 30 minute timeout for apply
+            ),
+        }
+    }
+}
+
+impl Default for TerraformApplyTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for TerraformApplyTool {
+    async fn execute(&self, input: ToolInput) -> AofResult<ToolResult> {
+        let path: String = input.get_arg("path").unwrap_or_else(|_| ".".to_string());
+        let auto_approve: bool = input.get_arg("auto_approve").unwrap_or(true);
+        let var: std::collections::HashMap<String, String> = input.get_arg("var").unwrap_or_default();
+        let var_file: Option<String> = input.get_arg("var_file").ok();
+        let target: Vec<String> = input.get_arg("target").unwrap_or_default();
+        let plan_file: Option<String> = input.get_arg("plan_file").ok();
+
+        let mut args = vec!["apply".to_string(), "-no-color".to_string()];
+
+        if auto_approve {
+            args.push("-auto-approve".to_string());
+        }
+
+        // If applying a plan file, don't add var/target options
+        if let Some(ref pf) = plan_file {
+            args.push(pf.clone());
+        } else {
+            for (key, value) in &var {
+                args.push(format!("-var={}={}", key, value));
+            }
+
+            if let Some(ref vf) = var_file {
+                args.push(format!("-var-file={}", vf));
+            }
+
+            for t in &target {
+                args.push(format!("-target={}", t));
+            }
+        }
+
+        debug!(args = ?args, path = %path, "Executing terraform apply");
+
+        let args_str: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        let result = execute_command("terraform", &args_str, Some(&path), 1800).await;
+
+        match result {
+            Ok(output) => {
+                if output.success {
+                    Ok(ToolResult::success(serde_json::json!({
+                        "applied": true,
+                        "output": output.stdout
+                    })))
+                } else {
+                    Ok(ToolResult::error(format!(
+                        "terraform apply failed: {}",
+                        output.stderr
+                    )))
+                }
+            }
+            Err(e) => Ok(ToolResult::error(e)),
+        }
+    }
+
+    fn config(&self) -> &ToolConfig {
+        &self.config
+    }
+}
+
+// ============================================================================
+// Terraform Destroy Tool
+// ============================================================================
+
+/// Destroy Terraform infrastructure
+pub struct TerraformDestroyTool {
+    config: ToolConfig,
+}
+
+impl TerraformDestroyTool {
+    pub fn new() -> Self {
+        let parameters = create_schema(
+            serde_json::json!({
+                "path": {
+                    "type": "string",
+                    "description": "Path to Terraform configuration",
+                    "default": "."
+                },
+                "auto_approve": {
+                    "type": "boolean",
+                    "description": "Skip interactive approval",
+                    "default": false
+                },
+                "var": {
+                    "type": "object",
+                    "description": "Variable values",
+                    "additionalProperties": { "type": "string" }
+                },
+                "var_file": {
+                    "type": "string",
+                    "description": "Path to variable file"
+                },
+                "target": {
+                    "type": "array",
+                    "description": "Resource addresses to target",
+                    "items": { "type": "string" }
+                }
+            }),
+            vec![],
+        );
+
+        Self {
+            config: tool_config_with_timeout(
+                "terraform_destroy",
+                "Destroy Terraform-managed infrastructure. USE WITH CAUTION.",
+                parameters,
+                1800,
+            ),
+        }
+    }
+}
+
+impl Default for TerraformDestroyTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for TerraformDestroyTool {
+    async fn execute(&self, input: ToolInput) -> AofResult<ToolResult> {
+        let path: String = input.get_arg("path").unwrap_or_else(|_| ".".to_string());
+        let auto_approve: bool = input.get_arg("auto_approve").unwrap_or(false);
+        let var: std::collections::HashMap<String, String> = input.get_arg("var").unwrap_or_default();
+        let var_file: Option<String> = input.get_arg("var_file").ok();
+        let target: Vec<String> = input.get_arg("target").unwrap_or_default();
+
+        // Safety check - require explicit auto_approve for destroy
+        if !auto_approve {
+            return Ok(ToolResult::error(
+                "terraform destroy requires 'auto_approve: true' for safety. This is a destructive operation."
+            ));
+        }
+
+        let mut args = vec![
+            "destroy".to_string(),
+            "-no-color".to_string(),
+            "-auto-approve".to_string(),
+        ];
+
+        for (key, value) in &var {
+            args.push(format!("-var={}={}", key, value));
+        }
+
+        if let Some(ref vf) = var_file {
+            args.push(format!("-var-file={}", vf));
+        }
+
+        for t in &target {
+            args.push(format!("-target={}", t));
+        }
+
+        debug!(args = ?args, path = %path, "Executing terraform destroy");
+
+        let args_str: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        let result = execute_command("terraform", &args_str, Some(&path), 1800).await;
+
+        match result {
+            Ok(output) => {
+                if output.success {
+                    Ok(ToolResult::success(serde_json::json!({
+                        "destroyed": true,
+                        "output": output.stdout
+                    })))
+                } else {
+                    Ok(ToolResult::error(format!(
+                        "terraform destroy failed: {}",
+                        output.stderr
+                    )))
+                }
+            }
+            Err(e) => Ok(ToolResult::error(e)),
+        }
+    }
+
+    fn config(&self) -> &ToolConfig {
+        &self.config
+    }
+}
+
+// ============================================================================
+// Terraform Output Tool
+// ============================================================================
+
+/// Get Terraform outputs
+pub struct TerraformOutputTool {
+    config: ToolConfig,
+}
+
+impl TerraformOutputTool {
+    pub fn new() -> Self {
+        let parameters = create_schema(
+            serde_json::json!({
+                "path": {
+                    "type": "string",
+                    "description": "Path to Terraform configuration",
+                    "default": "."
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Specific output name (omit for all)"
+                },
+                "json": {
+                    "type": "boolean",
+                    "description": "Output as JSON",
+                    "default": true
+                }
+            }),
+            vec![],
+        );
+
+        Self {
+            config: tool_config_with_timeout(
+                "terraform_output",
+                "Read output values from Terraform state.",
+                parameters,
+                60,
+            ),
+        }
+    }
+}
+
+impl Default for TerraformOutputTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for TerraformOutputTool {
+    async fn execute(&self, input: ToolInput) -> AofResult<ToolResult> {
+        let path: String = input.get_arg("path").unwrap_or_else(|_| ".".to_string());
+        let name: Option<String> = input.get_arg("name").ok();
+        let json: bool = input.get_arg("json").unwrap_or(true);
+
+        let mut args = vec!["output".to_string(), "-no-color".to_string()];
+
+        if json {
+            args.push("-json".to_string());
+        }
+
+        if let Some(ref n) = name {
+            args.push(n.clone());
+        }
+
+        debug!(args = ?args, path = %path, "Executing terraform output");
+
+        let args_str: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        let result = execute_command("terraform", &args_str, Some(&path), 60).await;
+
+        match result {
+            Ok(output) => {
+                if output.success {
+                    let outputs = if json {
+                        serde_json::from_str(&output.stdout).unwrap_or_else(|_| {
+                            serde_json::json!({ "raw": output.stdout })
+                        })
+                    } else {
+                        serde_json::json!({ "output": output.stdout })
+                    };
+
+                    Ok(ToolResult::success(serde_json::json!({
+                        "outputs": outputs
+                    })))
+                } else {
+                    Ok(ToolResult::error(format!(
+                        "terraform output failed: {}",
+                        output.stderr
+                    )))
+                }
+            }
+            Err(e) => Ok(ToolResult::error(e)),
+        }
+    }
+
+    fn config(&self) -> &ToolConfig {
+        &self.config
+    }
+}

--- a/aof/crates/aofctl/src/commands/run.rs
+++ b/aof/crates/aofctl/src/commands/run.rs
@@ -255,9 +255,9 @@ async fn run_agent_interactive(runtime: &Runtime, agent_name: &str, _output: &st
         .map(|agent| agent.config().model.clone())
         .unwrap_or_else(|| "unknown".to_string());
 
-    let tools = runtime
+    let tools: Vec<String> = runtime
         .get_agent(agent_name)
-        .map(|agent| agent.config().tools.clone())
+        .map(|agent| agent.config().tool_names().iter().map(|s| s.to_string()).collect())
         .unwrap_or_default();
 
     // Create log channel

--- a/aof/crates/aofctl/src/commands/validate.rs
+++ b/aof/crates/aofctl/src/commands/validate.rs
@@ -45,7 +45,8 @@ pub async fn execute(file: &str) -> Result<()> {
     }
 
     if !agent_config.tools.is_empty() {
-        println!("  Tools: {}", agent_config.tools.join(", "));
+        let tool_names: Vec<&str> = agent_config.tool_names();
+        println!("  Tools: {}", tool_names.join(", "));
     }
 
     if let Some(memory) = &agent_config.memory {

--- a/aof/docs/tools/index.md
+++ b/aof/docs/tools/index.md
@@ -1,0 +1,1054 @@
+# AOF Built-in Tools
+
+AOF provides a modular tool system that allows agents to interact with external systems, execute commands, and perform operations. Tools can be used directly as built-in Rust implementations or through MCP (Model Context Protocol) servers.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        Agent                                     │
+│                          │                                       │
+│                    ToolExecutor                                  │
+│                    /         \                                   │
+│         BuiltinToolExecutor   McpToolExecutor                   │
+│              │                     │                             │
+│    ┌─────────┴─────────┐    ┌─────┴─────┐                       │
+│    │    Tool Registry   │    │ MCP Server │                      │
+│    │  ┌───────────────┐ │    └───────────┘                       │
+│    │  │ FileTools     │ │                                        │
+│    │  │ ShellTool     │ │                                        │
+│    │  │ KubectlTools  │ │                                        │
+│    │  │ DockerTools   │ │                                        │
+│    │  │ GitTools      │ │                                        │
+│    │  │ TerraformTools│ │                                        │
+│    │  │ Observability │ │                                        │
+│    │  │ AwsTools      │ │                                        │
+│    │  └───────────────┘ │                                        │
+│    └────────────────────┘                                        │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Tool Categories
+
+| Category | Feature Flag | Tools | Description |
+|----------|--------------|-------|-------------|
+| [File](#file-tools) | `file` | read_file, write_file, list_directory, search_files | File system operations |
+| [Shell](#shell-tool) | `shell` | shell | Execute shell commands |
+| [Kubectl](#kubectl-tools) | `kubectl` | kubectl_get, kubectl_apply, kubectl_delete, kubectl_logs, kubectl_exec, kubectl_describe | Kubernetes operations |
+| [Docker](#docker-tools) | `docker` | docker_ps, docker_build, docker_run, docker_logs, docker_exec, docker_images | Container operations |
+| [Git](#git-tools) | `git` | git_status, git_diff, git_log, git_commit, git_branch, git_checkout, git_pull, git_push | Repository operations |
+| [Terraform](#terraform-tools) | `terraform` | terraform_init, terraform_plan, terraform_apply, terraform_destroy, terraform_output | IaC operations |
+| [HTTP](#http-tool) | `http` | http_request | HTTP requests |
+| [Observability](#observability-tools) | `observability` | prometheus_query, loki_query, elasticsearch_query, victoriametrics_query | Metrics & logs |
+| [AWS](#aws-tools) | `aws` | aws_s3, aws_ec2, aws_logs, aws_iam, aws_lambda, aws_ecs | AWS CLI operations |
+
+## Choosing Built-in vs MCP Tools
+
+### Use Built-in Tools When:
+- You need **low latency** (no subprocess overhead)
+- You want **fewer dependencies** (no Node.js/Python required)
+- You need **tighter integration** with the agent runtime
+- You're building **production deployments**
+
+### Use MCP Tools When:
+- You need **community-maintained** tool implementations
+- You want to use **existing MCP servers** from the ecosystem
+- You need **language-specific** tooling (npm packages, Python libraries)
+- You're **prototyping** and want quick integrations
+
+---
+
+## Tool Specification (ToolSpec)
+
+AOF uses a unified `ToolSpec` format that supports both built-in and MCP tools with optional configuration.
+
+### Spec Formats
+
+Tools can be specified in three formats:
+
+#### 1. Simple String (Backward Compatible)
+```yaml
+tools:
+  - shell
+  - kubectl_get
+  - git_status
+```
+Simple strings default to **built-in** tools.
+
+#### 2. Qualified Built-in Tool with Config
+```yaml
+tools:
+  - name: shell
+    source: builtin
+    config:
+      blocked_commands:
+        - "rm -rf /"
+        - "mkfs"
+      timeout_secs: 60
+    timeout_secs: 120  # Override default timeout
+```
+
+#### 3. Qualified MCP Tool
+```yaml
+tools:
+  - name: read_file
+    source: mcp
+    server: filesystem   # References an MCP server by name
+    config:
+      allowed_paths:
+        - /workspace
+        - /home/user/projects
+```
+
+### ToolSpec Properties
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `name` | string | Yes | Tool name |
+| `source` | string | No | `builtin` (default) or `mcp` |
+| `server` | string | If MCP | MCP server name (must match an entry in `mcp_servers`) |
+| `config` | object | No | Tool-specific configuration |
+| `enabled` | boolean | No | Enable/disable tool (default: true) |
+| `timeout_secs` | integer | No | Override default timeout |
+
+---
+
+## Configuration Examples
+
+### Using Built-in Tools Only
+
+```yaml
+apiVersion: aof.dev/v1
+kind: Agent
+metadata:
+  name: devops-agent
+spec:
+  model: openai:gpt-4o
+  instructions: |
+    You are a DevOps engineer assistant.
+  tools:
+    - shell
+    - kubectl_get
+    - kubectl_logs
+    - docker_ps
+    - git_status
+```
+
+### Using MCP Tools Only
+
+```yaml
+apiVersion: aof.dev/v1
+kind: Agent
+metadata:
+  name: devops-agent-mcp
+spec:
+  model: openai:gpt-4o
+  instructions: |
+    You are a DevOps engineer assistant.
+  mcp_servers:
+    - name: kubectl-ai
+      transport: stdio
+      command: kubectl-ai
+      args: ["--mcp-server"]
+    - name: filesystem
+      transport: stdio
+      command: npx
+      args: ["@modelcontextprotocol/server-filesystem", "/workspace"]
+```
+
+### Hybrid: Built-in + MCP Tools
+
+```yaml
+apiVersion: aof.dev/v1
+kind: Agent
+metadata:
+  name: hybrid-agent
+spec:
+  model: openai:gpt-4o
+  instructions: |
+    You are a DevOps engineer assistant.
+  tools:
+    # Simple built-in tools
+    - shell
+    - git_status
+
+    # Built-in with custom config
+    - name: kubectl_get
+      source: builtin
+      timeout_secs: 120
+
+    # MCP tool from a server
+    - name: github_search
+      source: mcp
+      server: github
+
+  mcp_servers:
+    - name: github
+      transport: stdio
+      command: npx
+      args: ["@modelcontextprotocol/server-github"]
+      env:
+        GITHUB_TOKEN: "${GITHUB_TOKEN}"
+```
+
+### Built-in Tools with Security Config
+
+```yaml
+apiVersion: aof.dev/v1
+kind: Agent
+metadata:
+  name: secure-agent
+spec:
+  model: openai:gpt-4o
+  instructions: |
+    You are a secure operations assistant.
+  tools:
+    - name: shell
+      source: builtin
+      config:
+        blocked_commands:
+          - "rm -rf"
+          - "mkfs"
+          - "dd"
+          - "> /dev"
+        allowed_commands:
+          - "ls"
+          - "cat"
+          - "grep"
+          - "find"
+        timeout_secs: 30
+
+    - name: read_file
+      source: builtin
+      config:
+        max_bytes: 1048576  # 1MB limit
+        allowed_paths:
+          - /workspace
+          - /tmp
+```
+
+### MCP Tools with Arguments
+
+```yaml
+apiVersion: aof.dev/v1
+kind: Agent
+metadata:
+  name: mcp-configured-agent
+spec:
+  model: openai:gpt-4o
+  instructions: |
+    You are a code assistant.
+  tools:
+    - name: search_code
+      source: mcp
+      server: sourcegraph
+      config:
+        default_repo: "github.com/myorg/myrepo"
+        max_results: 50
+
+  mcp_servers:
+    - name: sourcegraph
+      transport: http
+      endpoint: http://sourcegraph.internal/mcp
+      init_options:
+        token: "${SOURCEGRAPH_TOKEN}"
+        default_context: "myorg"
+```
+
+---
+
+## File Tools
+
+File system operations for reading, writing, and searching files.
+
+### read_file
+
+Read contents of a file.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| path | string | Yes | Path to file |
+| encoding | string | No | File encoding (default: utf-8) |
+| max_bytes | integer | No | Max bytes to read (default: 1MB) |
+
+**Example:**
+```json
+{
+  "path": "/app/config.yaml",
+  "max_bytes": 10000
+}
+```
+
+### write_file
+
+Write content to a file.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| path | string | Yes | Path to file |
+| content | string | Yes | Content to write |
+| append | boolean | No | Append mode (default: false) |
+| create_dirs | boolean | No | Create parent dirs (default: true) |
+
+### list_directory
+
+List contents of a directory.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| path | string | Yes | Directory path |
+| recursive | boolean | No | List recursively (default: false) |
+| include_hidden | boolean | No | Include hidden files (default: false) |
+| max_depth | integer | No | Max recursion depth (default: 3) |
+
+### search_files
+
+Search for files matching a pattern.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| pattern | string | Yes | Glob pattern (e.g., `**/*.rs`) |
+| path | string | No | Base path (default: `.`) |
+| max_results | integer | No | Max results (default: 100) |
+
+**MCP Alternative:** `@modelcontextprotocol/server-filesystem`
+
+---
+
+## Shell Tool
+
+Execute shell commands with safety controls.
+
+### shell
+
+Execute a shell command.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| command | string | Yes | Command to execute |
+| working_dir | string | No | Working directory |
+| timeout_secs | integer | No | Timeout (default: 60) |
+| env | object | No | Environment variables |
+
+**Security Features:**
+- Blocked dangerous commands (rm -rf /, mkfs, etc.)
+- Timeout protection
+- Optional command whitelist
+
+**Example:**
+```json
+{
+  "command": "kubectl get pods -n production",
+  "timeout_secs": 30
+}
+```
+
+---
+
+## Kubectl Tools
+
+Kubernetes operations via kubectl CLI.
+
+### kubectl_get
+
+Get Kubernetes resources.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| resource | string | Yes | Resource type (pods, deployments, etc.) |
+| name | string | No | Resource name |
+| namespace | string | No | Namespace |
+| all_namespaces | boolean | No | All namespaces (-A) |
+| output | string | No | Format: json, yaml, wide, name |
+| selector | string | No | Label selector |
+| field_selector | string | No | Field selector |
+
+**Example:**
+```json
+{
+  "resource": "pods",
+  "namespace": "production",
+  "selector": "app=nginx",
+  "output": "json"
+}
+```
+
+### kubectl_apply
+
+Apply Kubernetes manifests.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| manifest | string | No | YAML manifest content |
+| file | string | No | Path to manifest file |
+| namespace | string | No | Namespace |
+| dry_run | string | No | none, client, server |
+| force | boolean | No | Force apply |
+
+### kubectl_delete
+
+Delete Kubernetes resources.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| resource | string | Yes | Resource type |
+| name | string | No | Resource name |
+| namespace | string | No | Namespace |
+| selector | string | No | Label selector |
+| force | boolean | No | Force delete |
+| grace_period | integer | No | Grace period (default: 30) |
+
+### kubectl_logs
+
+Get pod logs.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| pod | string | Yes | Pod name |
+| namespace | string | No | Namespace |
+| container | string | No | Container name |
+| tail | integer | No | Lines from end (default: 100) |
+| since | string | No | Duration (e.g., '5m', '1h') |
+| previous | boolean | No | Previous instance |
+| timestamps | boolean | No | Show timestamps |
+
+### kubectl_exec
+
+Execute commands in containers.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| pod | string | Yes | Pod name |
+| command | string | Yes | Command to execute |
+| namespace | string | No | Namespace |
+| container | string | No | Container name |
+
+### kubectl_describe
+
+Describe resources.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| resource | string | Yes | Resource type |
+| name | string | Yes | Resource name |
+| namespace | string | No | Namespace |
+
+**MCP Alternative:** `kubectl-ai --mcp-server`
+
+---
+
+## Docker Tools
+
+Docker container operations.
+
+### docker_ps
+
+List containers.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| all | boolean | No | Show all containers |
+| filter | string | No | Filter (e.g., 'status=running') |
+| format | string | No | Output format |
+
+### docker_build
+
+Build images.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| path | string | No | Build context (default: .) |
+| tag | string | Yes | Image tag |
+| dockerfile | string | No | Dockerfile path |
+| build_args | object | No | Build arguments |
+| no_cache | boolean | No | Don't use cache |
+| target | string | No | Target stage |
+| platform | string | No | Target platform |
+
+### docker_run
+
+Run containers.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| image | string | Yes | Image name |
+| name | string | No | Container name |
+| command | string | No | Command |
+| detach | boolean | No | Run in background |
+| rm | boolean | No | Remove after exit (default: true) |
+| ports | array | No | Port mappings |
+| volumes | array | No | Volume mounts |
+| env | object | No | Environment variables |
+| network | string | No | Network |
+
+### docker_logs
+
+Get container logs.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| container | string | Yes | Container name/ID |
+| tail | integer | No | Lines (default: 100) |
+| since | string | No | Duration |
+| timestamps | boolean | No | Show timestamps |
+
+### docker_exec
+
+Execute in containers.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| container | string | Yes | Container name/ID |
+| command | string | Yes | Command |
+| user | string | No | User |
+| workdir | string | No | Working directory |
+
+### docker_images
+
+List images.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| all | boolean | No | Show all images |
+| filter | string | No | Filter |
+
+---
+
+## Git Tools
+
+Git repository operations.
+
+### git_status
+
+Show working tree status.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| path | string | No | Repository path (default: .) |
+| short | boolean | No | Short format |
+| porcelain | boolean | No | Machine-readable (default: true) |
+
+### git_diff
+
+Show changes.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| path | string | No | Repository path |
+| file | string | No | Specific file |
+| staged | boolean | No | Show staged changes |
+| commit | string | No | Compare with commit |
+| stat | boolean | No | Show diffstat |
+
+### git_log
+
+Show commit history.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| path | string | No | Repository path |
+| count | integer | No | Number of commits (default: 10) |
+| oneline | boolean | No | One line per commit |
+| author | string | No | Filter by author |
+| since | string | No | Since date |
+| file | string | No | File history |
+
+### git_commit
+
+Create commits.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| message | string | Yes | Commit message |
+| path | string | No | Repository path |
+| all | boolean | No | Stage all (-a) |
+| files | array | No | Files to commit |
+
+### git_branch
+
+List/create branches.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| path | string | No | Repository path |
+| name | string | No | Branch to create |
+| delete | string | No | Branch to delete |
+| all | boolean | No | List all branches |
+
+### git_checkout
+
+Switch branches.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| branch | string | No | Branch name |
+| path | string | No | Repository path |
+| create | boolean | No | Create new branch |
+| file | string | No | Checkout file |
+
+### git_pull / git_push
+
+Pull/push changes.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| path | string | No | Repository path |
+| remote | string | No | Remote name (default: origin) |
+| branch | string | No | Branch |
+| rebase | boolean | No | Rebase (pull only) |
+| set_upstream | boolean | No | Set upstream (push only) |
+| tags | boolean | No | Push tags |
+
+---
+
+## Terraform Tools
+
+Terraform IaC operations.
+
+### terraform_init
+
+Initialize Terraform.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| path | string | No | Configuration path |
+| upgrade | boolean | No | Upgrade providers |
+| reconfigure | boolean | No | Reconfigure backend |
+| backend_config | object | No | Backend config values |
+
+### terraform_plan
+
+Create execution plan.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| path | string | No | Configuration path |
+| out | string | No | Save plan to file |
+| var | object | No | Variables |
+| var_file | string | No | Variable file |
+| target | array | No | Target resources |
+| destroy | boolean | No | Create destroy plan |
+
+### terraform_apply
+
+Apply changes.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| path | string | No | Configuration path |
+| auto_approve | boolean | No | Skip approval (default: true) |
+| var | object | No | Variables |
+| var_file | string | No | Variable file |
+| target | array | No | Target resources |
+| plan_file | string | No | Apply saved plan |
+
+### terraform_destroy
+
+Destroy infrastructure.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| path | string | No | Configuration path |
+| auto_approve | boolean | No | Skip approval (REQUIRED for safety) |
+| var | object | No | Variables |
+| target | array | No | Target resources |
+
+### terraform_output
+
+Get outputs.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| path | string | No | Configuration path |
+| name | string | No | Output name |
+| json | boolean | No | JSON format (default: true) |
+
+---
+
+## HTTP Tool
+
+Make HTTP requests.
+
+### http_request
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| url | string | Yes | Request URL |
+| method | string | No | HTTP method (default: GET) |
+| headers | object | No | Request headers |
+| body | string | No | Request body |
+| json | object | No | JSON body |
+| timeout_secs | integer | No | Timeout (default: 30) |
+| follow_redirects | boolean | No | Follow redirects (default: true) |
+
+**MCP Alternative:** `@anthropic/mcp-server-fetch`
+
+---
+
+## Observability Tools
+
+Query observability platforms for metrics and logs.
+
+### prometheus_query
+
+Query Prometheus metrics.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| endpoint | string | Yes | Prometheus URL |
+| query | string | Yes | PromQL query |
+| time | string | No | Evaluation time |
+| start | string | No | Range start |
+| end | string | No | Range end |
+| step | string | No | Step (default: 15s) |
+| timeout | string | No | Timeout (default: 30s) |
+
+**Example:**
+```json
+{
+  "endpoint": "http://prometheus:9090",
+  "query": "sum(rate(http_requests_total[5m])) by (service)",
+  "start": "2024-01-01T00:00:00Z",
+  "end": "2024-01-01T01:00:00Z",
+  "step": "1m"
+}
+```
+
+### loki_query
+
+Query Loki logs.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| endpoint | string | Yes | Loki URL |
+| query | string | Yes | LogQL query |
+| start | string | No | Start time |
+| end | string | No | End time |
+| limit | integer | No | Max entries (default: 100) |
+| direction | string | No | forward or backward |
+
+**Example:**
+```json
+{
+  "endpoint": "http://loki:3100",
+  "query": "{namespace=\"production\"} |= \"error\"",
+  "limit": 50
+}
+```
+
+### elasticsearch_query
+
+Query Elasticsearch/OpenSearch.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| endpoint | string | Yes | Elasticsearch URL |
+| index | string | Yes | Index pattern |
+| query | object | No | Query DSL |
+| size | integer | No | Results (default: 10) |
+| from | integer | No | Offset (default: 0) |
+| sort | array | No | Sort spec |
+| source | array | No | Fields to include |
+| auth | object | No | {username, password} |
+
+**Example:**
+```json
+{
+  "endpoint": "http://elasticsearch:9200",
+  "index": "logs-*",
+  "query": {
+    "bool": {
+      "must": [
+        {"match": {"level": "error"}},
+        {"range": {"@timestamp": {"gte": "now-1h"}}}
+      ]
+    }
+  },
+  "size": 20
+}
+```
+
+### victoriametrics_query
+
+Query VictoriaMetrics.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| endpoint | string | Yes | VictoriaMetrics URL |
+| query | string | Yes | MetricsQL query |
+| time | string | No | Evaluation time |
+| start | string | No | Range start |
+| end | string | No | Range end |
+| step | string | No | Step (default: 15s) |
+
+---
+
+## AWS Tools
+
+AWS CLI operations via the `aws` command-line tool.
+
+### aws_s3
+
+S3 operations (ls, cp, sync, rm).
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| operation | string | Yes | Operation: ls, cp, sync, rm, mb, rb |
+| source | string | Depends | Source path (for cp, sync) |
+| destination | string | Depends | Destination path (for cp, sync) |
+| bucket | string | Depends | Bucket name (for ls, mb, rb) |
+| prefix | string | No | Key prefix for listing |
+| recursive | boolean | No | Recursive operation |
+| delete | boolean | No | Delete during sync |
+| profile | string | No | AWS profile |
+| region | string | No | AWS region |
+
+**Example:**
+```json
+{
+  "operation": "ls",
+  "bucket": "my-bucket",
+  "prefix": "logs/",
+  "recursive": true
+}
+```
+
+### aws_ec2
+
+EC2 instance operations.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| operation | string | Yes | describe-instances, start-instances, stop-instances, etc. |
+| instance_ids | array | Depends | Instance IDs |
+| filters | array | No | Filter expressions |
+| query | string | No | JMESPath query |
+| profile | string | No | AWS profile |
+| region | string | No | AWS region |
+
+**Example:**
+```json
+{
+  "operation": "describe-instances",
+  "filters": [
+    {"Name": "instance-state-name", "Values": ["running"]}
+  ],
+  "query": "Reservations[*].Instances[*].[InstanceId,InstanceType,State.Name]"
+}
+```
+
+### aws_logs
+
+CloudWatch Logs operations.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| operation | string | Yes | filter-log-events, describe-log-groups, tail-logs |
+| log_group | string | Yes | Log group name |
+| log_stream | string | No | Log stream name |
+| filter_pattern | string | No | Filter pattern |
+| start_time | string | No | Start time (ISO8601 or epoch ms) |
+| end_time | string | No | End time |
+| limit | integer | No | Max events (default: 100) |
+| profile | string | No | AWS profile |
+| region | string | No | AWS region |
+
+**Example:**
+```json
+{
+  "operation": "filter-log-events",
+  "log_group": "/aws/lambda/my-function",
+  "filter_pattern": "ERROR",
+  "start_time": "2024-01-01T00:00:00Z",
+  "limit": 50
+}
+```
+
+### aws_iam
+
+IAM operations.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| operation | string | Yes | list-users, list-roles, get-user, get-role, etc. |
+| user_name | string | Depends | User name |
+| role_name | string | Depends | Role name |
+| policy_arn | string | Depends | Policy ARN |
+| profile | string | No | AWS profile |
+| region | string | No | AWS region |
+
+### aws_lambda
+
+Lambda operations.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| operation | string | Yes | list-functions, get-function, invoke |
+| function_name | string | Depends | Function name |
+| payload | object | No | Invocation payload (for invoke) |
+| qualifier | string | No | Version or alias |
+| profile | string | No | AWS profile |
+| region | string | No | AWS region |
+
+**Example:**
+```json
+{
+  "operation": "invoke",
+  "function_name": "my-function",
+  "payload": {"key": "value"}
+}
+```
+
+### aws_ecs
+
+ECS operations.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| operation | string | Yes | list-clusters, list-services, describe-services, etc. |
+| cluster | string | Depends | Cluster name/ARN |
+| service | string | Depends | Service name |
+| task | string | Depends | Task ID |
+| profile | string | No | AWS profile |
+| region | string | No | AWS region |
+
+**Example:**
+```json
+{
+  "operation": "describe-services",
+  "cluster": "production",
+  "service": "web-api"
+}
+```
+
+**MCP Alternative:** `@aws/mcp-server-aws`
+
+---
+
+## Building Custom Tools
+
+Platform engineers can extend AOF with custom tools:
+
+```rust
+use aof_core::{Tool, ToolConfig, ToolInput, ToolResult, AofResult};
+use async_trait::async_trait;
+
+pub struct MyCustomTool {
+    config: ToolConfig,
+}
+
+impl MyCustomTool {
+    pub fn new() -> Self {
+        Self {
+            config: ToolConfig {
+                name: "my_tool".to_string(),
+                description: "My custom tool".to_string(),
+                parameters: serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "input": {"type": "string"}
+                    },
+                    "required": ["input"]
+                }),
+                tool_type: aof_core::ToolType::Custom,
+                timeout_secs: 30,
+                extra: Default::default(),
+            },
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for MyCustomTool {
+    async fn execute(&self, input: ToolInput) -> AofResult<ToolResult> {
+        let my_input: String = input.get_arg("input")?;
+
+        // Your logic here
+
+        Ok(ToolResult::success(serde_json::json!({
+            "result": "success"
+        })))
+    }
+
+    fn config(&self) -> &ToolConfig {
+        &self.config
+    }
+}
+```
+
+Register your tool:
+
+```rust
+use aof_tools::{ToolRegistry, BuiltinToolExecutor};
+
+let mut registry = ToolRegistry::new();
+registry.register(MyCustomTool::new());
+let executor = registry.into_executor();
+```
+
+---
+
+## Feature Flags
+
+Enable only the tools you need in `Cargo.toml`:
+
+```toml
+[dependencies]
+aof-tools = { version = "0.1", features = ["file", "shell", "kubectl"] }
+
+# Or enable all
+aof-tools = { version = "0.1", features = ["all"] }
+```
+
+| Feature | Description |
+|---------|-------------|
+| `file` | File system tools |
+| `shell` | Shell execution |
+| `kubectl` | Kubernetes tools |
+| `docker` | Docker tools |
+| `git` | Git tools |
+| `terraform` | Terraform tools |
+| `http` | HTTP client |
+| `observability` | Prometheus, Loki, ELK, VictoriaMetrics |
+| `aws` | AWS CLI tools (S3, EC2, Lambda, etc.) |
+| `all` | All tools |

--- a/aof/examples/agents/aws-agent.yaml
+++ b/aof/examples/agents/aws-agent.yaml
@@ -1,0 +1,85 @@
+# AWS Operations Agent
+# Uses built-in AWS CLI tools for cloud infrastructure management
+apiVersion: aof.dev/v1
+kind: Agent
+metadata:
+  name: aws-agent
+  labels:
+    category: cloud
+    tier: production
+
+spec:
+  model: openai:gpt-4o
+  instructions: |
+    You are an AWS cloud operations specialist. You help with:
+    - EC2 instance management
+    - S3 bucket operations
+    - CloudWatch logs analysis
+    - Lambda function operations
+    - ECS service management
+    - IAM user and role management
+
+    ## AWS Best Practices:
+    - Always use the principle of least privilege
+    - Check current state before making changes
+    - Use appropriate regions for operations
+    - Verify resource IDs before modifications
+    - Be cautious with destructive operations
+
+    ## Safety Rules:
+    - NEVER delete resources without explicit confirmation
+    - Always verify the correct AWS profile is being used
+    - Double-check instance IDs before stop/terminate operations
+    - Review IAM changes carefully before applying
+
+  tools:
+    # AWS S3 operations
+    - name: aws_s3
+      source: builtin
+      config:
+        default_region: us-east-1
+
+    # AWS EC2 operations
+    - name: aws_ec2
+      source: builtin
+      config:
+        default_region: us-east-1
+
+    # CloudWatch Logs
+    - name: aws_logs
+      source: builtin
+      config:
+        default_region: us-east-1
+        default_limit: 50
+
+    # IAM operations
+    - name: aws_iam
+      source: builtin
+
+    # Lambda operations
+    - name: aws_lambda
+      source: builtin
+      config:
+        default_region: us-east-1
+
+    # ECS operations
+    - name: aws_ecs
+      source: builtin
+      config:
+        default_region: us-east-1
+
+    # Shell for AWS CLI commands not covered by tools
+    - name: shell
+      source: builtin
+      config:
+        blocked_commands:
+          - "rm -rf"
+        timeout_secs: 60
+
+  max_iterations: 20
+  temperature: 0.2
+
+  # Environment variables for AWS
+  env:
+    AWS_PROFILE: "default"
+    AWS_DEFAULT_REGION: "us-east-1"

--- a/aof/examples/agents/devops-agent.yaml
+++ b/aof/examples/agents/devops-agent.yaml
@@ -1,0 +1,60 @@
+# DevOps Agent with Built-in Tools
+# This agent can perform common DevOps tasks using AOF's built-in tools
+apiVersion: aof.dev/v1
+kind: Agent
+metadata:
+  name: devops-agent
+  labels:
+    category: devops
+    tier: production
+
+spec:
+  model: openai:gpt-4o
+  instructions: |
+    You are an experienced DevOps engineer assistant. You help with:
+    - Kubernetes cluster management and troubleshooting
+    - Docker container operations
+    - Git repository management
+    - Infrastructure automation
+    - System administration tasks
+
+    ## Guidelines:
+    - Always check the current state before making changes
+    - Use dry-run mode for destructive operations when available
+    - Provide clear explanations of what you're doing
+    - Log important operations for audit purposes
+
+    ## Safety Rules:
+    - Never delete resources without confirmation
+    - Always backup configurations before modifying
+    - Use namespaces to scope operations
+    - Follow the principle of least privilege
+
+  tools:
+    # Kubernetes operations
+    - kubectl_get
+    - kubectl_apply
+    - kubectl_logs
+    - kubectl_describe
+    - kubectl_exec
+
+    # Docker operations
+    - docker_ps
+    - docker_logs
+    - docker_images
+
+    # Git operations
+    - git_status
+    - git_diff
+    - git_log
+
+    # File operations
+    - read_file
+    - write_file
+    - list_directory
+
+    # Shell for advanced operations
+    - shell
+
+  max_iterations: 20
+  temperature: 0.3

--- a/aof/examples/agents/hybrid-agent.yaml
+++ b/aof/examples/agents/hybrid-agent.yaml
@@ -1,0 +1,69 @@
+# Hybrid Agent Example - Using both Built-in and MCP tools
+# Demonstrates the unified ToolSpec format with configuration options
+apiVersion: aof.dev/v1
+kind: Agent
+metadata:
+  name: hybrid-agent
+  labels:
+    category: devops
+    tier: production
+
+spec:
+  model: openai:gpt-4o
+  instructions: |
+    You are a DevOps engineer with access to both built-in AOF tools
+    and MCP-based tools. Use the appropriate tool for each task.
+
+    ## Available Tool Categories:
+    - Built-in: kubectl, docker, git, shell (fast, low latency)
+    - MCP: GitHub API (advanced features via MCP server)
+
+    ## Guidelines:
+    - Use built-in tools for common operations
+    - Use MCP tools for advanced features not in built-in set
+    - Always verify operations before making changes
+
+  tools:
+    # Simple built-in tools (string format)
+    - kubectl_get
+    - kubectl_logs
+    - docker_ps
+    - git_status
+
+    # Built-in tool with custom configuration
+    - name: shell
+      source: builtin
+      config:
+        blocked_commands:
+          - "rm -rf /"
+          - "mkfs"
+          - "dd if=/dev"
+        timeout_secs: 30
+
+    # Built-in tool with timeout override
+    - name: kubectl_exec
+      source: builtin
+      timeout_secs: 120  # Longer timeout for exec operations
+
+    # MCP tool referencing server below
+    - name: search_code
+      source: mcp
+      server: github
+      config:
+        max_results: 20
+
+    - name: create_issue
+      source: mcp
+      server: github
+
+  # MCP servers for tools that reference them
+  mcp_servers:
+    - name: github
+      transport: stdio
+      command: npx
+      args: ["@modelcontextprotocol/server-github"]
+      env:
+        GITHUB_TOKEN: "${GITHUB_TOKEN}"
+
+  max_iterations: 25
+  temperature: 0.3

--- a/aof/examples/agents/sre-agent.yaml
+++ b/aof/examples/agents/sre-agent.yaml
@@ -1,0 +1,60 @@
+# SRE Agent with Observability Tools
+# This agent monitors systems and helps with incident response
+apiVersion: aof.dev/v1
+kind: Agent
+metadata:
+  name: sre-agent
+  labels:
+    category: sre
+    tier: production
+
+spec:
+  model: openai:gpt-4o
+  instructions: |
+    You are a Site Reliability Engineer assistant specializing in:
+    - System monitoring and alerting
+    - Incident response and troubleshooting
+    - Performance analysis and optimization
+    - Capacity planning
+
+    ## Monitoring Stack:
+    - Prometheus for metrics
+    - Loki for logs
+    - Grafana for visualization (read-only)
+
+    ## Incident Response Process:
+    1. Acknowledge and assess severity
+    2. Gather metrics and logs
+    3. Identify root cause
+    4. Implement fix or mitigation
+    5. Document findings
+
+    ## Key Metrics to Monitor:
+    - Error rates (5xx responses)
+    - Latency percentiles (p50, p95, p99)
+    - Resource utilization (CPU, memory, disk)
+    - Request throughput
+    - Pod health and restarts
+
+  tools:
+    # Observability
+    - prometheus_query
+    - loki_query
+
+    # Kubernetes for investigation
+    - kubectl_get
+    - kubectl_logs
+    - kubectl_describe
+    - kubectl_exec
+
+    # File operations for configs
+    - read_file
+    - list_directory
+
+  max_iterations: 30
+  temperature: 0.2
+
+  # Environment variables for observability endpoints
+  env:
+    PROMETHEUS_URL: "http://prometheus:9090"
+    LOKI_URL: "http://loki:3100"

--- a/aof/examples/agents/terraform-agent.yaml
+++ b/aof/examples/agents/terraform-agent.yaml
@@ -1,0 +1,57 @@
+# Terraform Agent for Infrastructure as Code
+# Manages infrastructure using Terraform
+apiVersion: aof.dev/v1
+kind: Agent
+metadata:
+  name: terraform-agent
+  labels:
+    category: infrastructure
+    tier: production
+
+spec:
+  model: openai:gpt-4o
+  instructions: |
+    You are an Infrastructure as Code specialist using Terraform. You help with:
+    - Writing and reviewing Terraform configurations
+    - Planning and applying infrastructure changes
+    - Managing Terraform state
+    - Troubleshooting infrastructure issues
+
+    ## Terraform Workflow:
+    1. Initialize workspace (terraform init)
+    2. Review plan (terraform plan)
+    3. Apply changes (terraform apply)
+    4. Verify outputs
+
+    ## Best Practices:
+    - Always run plan before apply
+    - Use workspaces for environments
+    - Lock state files during operations
+    - Version pin providers
+    - Use modules for reusability
+
+    ## Safety Rules:
+    - NEVER run terraform destroy without explicit confirmation
+    - Always review plan output carefully
+    - Use -target for specific resources when needed
+    - Backup state before major changes
+
+  tools:
+    - terraform_init
+    - terraform_plan
+    - terraform_apply
+    - terraform_output
+
+    # File operations for HCL files
+    - read_file
+    - write_file
+    - list_directory
+    - search_files
+
+    # Git for version control
+    - git_status
+    - git_diff
+    - git_commit
+
+  max_iterations: 15
+  temperature: 0.2

--- a/docs/internal/LANDING_PAGE_SPEC.md
+++ b/docs/internal/LANDING_PAGE_SPEC.md
@@ -1,0 +1,863 @@
+# AOF Landing Page Specification
+
+**Target URL**: https://aof.sh
+**Documentation Link**: https://docs.aof.sh/docs/intro
+**Builder.io Implementation Guide**
+
+---
+
+## Page Overview
+
+**Goal**: Convert DevOps/SRE/Platform Engineers to try AOF by demonstrating it's the only AI agent framework built specifically for operations teams.
+
+**Primary CTA**: "Get Started" → https://docs.aof.sh/docs/intro
+**Secondary CTA**: "View on GitHub" → https://github.com/agenticdevops/aof
+
+---
+
+## Section 1: Hero
+
+### Layout
+- Full-width hero with dark gradient background (zinc-950 to zinc-900)
+- Centered content with animated terminal preview on right
+
+### Content
+
+**Tagline** (small, above headline):
+```
+The AI Agent Framework Built for Operations
+```
+
+**Headline** (H1, large, bold):
+```
+n8n for Agentic Ops
+```
+
+**Subheadline** (H2, medium):
+```
+Build AI agents with Kubernetes-style YAML. No Python required.
+```
+
+**Description** (paragraph):
+```
+AOF is the only AI agent framework designed from the ground up for DevOps, SRE,
+and Platform Engineers. Define agents in YAML, run with kubectl-style commands,
+deploy anywhere—no Kubernetes required. Native integrations with Slack, PagerDuty,
+Jira, Discord, GitHub, and more.
+```
+
+**Primary CTA Button** (large, orange-700 background):
+```
+Get Started in 5 Minutes →
+```
+Link: https://docs.aof.sh/docs/intro
+
+**Secondary CTA** (outline button):
+```
+View on GitHub
+```
+Link: https://github.com/agenticdevops/aof
+
+**Terminal Preview** (animated, dark theme):
+```yaml
+# my-agent.yaml
+apiVersion: aof.dev/v1
+kind: Agent
+metadata:
+  name: k8s-helper
+spec:
+  model: openai:gpt-4
+  instructions: |
+    You are a Kubernetes expert assistant.
+    Help users troubleshoot pod issues.
+  tools:
+    - shell
+```
+
+```bash
+$ aofctl run agent my-agent.yaml
+> Agent 'k8s-helper' is ready. Type your message:
+> Why is my pod in CrashLoopBackOff?
+```
+
+---
+
+## Section 2: The Problem
+
+### Layout
+- 3-column grid on dark background
+- Pain point icons with descriptions
+
+### Headline
+```
+AI Frameworks Weren't Built for Ops
+```
+
+### Pain Points
+
+**Column 1: Icon - Code brackets**
+```
+Title: "Learn Python First"
+Description: LangChain, CrewAI, and Agno require you to write Python code.
+Your team manages YAML all day—why learn a new language for AI?
+```
+
+**Column 2: Icon - Kubernetes logo**
+```
+Title: "Kubernetes Required"
+Description: Kagent ties you to Kubernetes. What about your VMs,
+bare metal servers, or hybrid infrastructure?
+```
+
+**Column 3: Icon - Puzzle pieces**
+```
+Title: "Complex Dependencies"
+Description: Python virtual environments, pip dependencies, version conflicts.
+More infrastructure to manage just to run an agent.
+```
+
+---
+
+## Section 3: The Solution - Why AOF
+
+### Layout
+- Large feature blocks with code examples
+- Alternating left/right layout
+
+### Headline
+```
+Built for Ops, By Ops
+```
+
+### Subheadline
+```
+If you know kubectl, you already know AOF.
+```
+
+### Feature Block 1: YAML-First
+
+**Title**: Define Agents Like K8s Resources
+
+**Description**:
+```
+No Python. No code. Just YAML you already understand. AOF uses the same
+declarative patterns you use for Kubernetes manifests, Terraform configs,
+and Ansible playbooks.
+```
+
+**Code Example**:
+```yaml
+apiVersion: aof.dev/v1
+kind: Agent
+metadata:
+  name: incident-responder
+  labels:
+    team: sre
+    env: production
+spec:
+  model: anthropic:claude-3-5-sonnet-20241022
+  instructions: |
+    You are an SRE assistant. Diagnose incidents,
+    suggest fixes, and execute approved remediations.
+  tools:
+    - type: Shell
+      config:
+        allowed_commands: [kubectl, helm, docker]
+    - type: Slack
+    - type: PagerDuty
+```
+
+### Feature Block 2: kubectl-Style CLI
+
+**Title**: Commands You Already Know
+
+**Description**:
+```
+apply, get, describe, logs, delete—AOF's CLI mirrors kubectl exactly.
+Your muscle memory works here. No new workflows to learn.
+```
+
+**Code Example**:
+```bash
+# Apply configuration
+aofctl apply -f agent.yaml
+
+# Get resources
+aofctl get agents
+
+# Run interactively
+aofctl run agent my-agent.yaml
+
+# Check logs
+aofctl logs agent my-agent
+
+# Delete when done
+aofctl delete agent my-agent
+```
+
+### Feature Block 3: Zero Dependencies
+
+**Title**: Single Binary. Runs Anywhere.
+
+**Description**:
+```
+Built in Rust for speed and reliability. One binary, zero dependencies.
+No Python, no Node.js, no virtual environments. Install and run in seconds.
+```
+
+**Installation Example**:
+```bash
+# That's it. You're done.
+cargo install aofctl
+
+# Or download the binary
+curl -sSL https://aof.sh/install.sh | bash
+```
+
+### Feature Block 4: No Kubernetes Required
+
+**Title**: Deploy Anywhere—K8s Optional
+
+**Description**:
+```
+Unlike Kagent, AOF doesn't require Kubernetes. Run agents on your laptop,
+VMs, bare metal, Docker, or yes—Kubernetes too. Your infrastructure, your choice.
+```
+
+**Deployment Options** (icon grid):
+- Laptop/Local
+- VMs (EC2, GCE, Azure VMs)
+- Bare Metal
+- Docker/Containers
+- Kubernetes (optional)
+- Serverless (AWS Lambda, Cloud Run)
+
+---
+
+## Section 4: Feature Comparison Table
+
+### Layout
+- Full-width table with sticky header
+- Checkmarks/X marks for feature support
+- AOF column highlighted
+
+### Headline
+```
+How AOF Compares
+```
+
+### Table Structure
+
+| Feature | AOF | LangChain | CrewAI | Kagent | Agno |
+|---------|-----|-----------|--------|--------|------|
+| **Configuration** | YAML | Python | Python | YAML (K8s CRD) | Python |
+| **CLI Style** | kubectl-like | Custom | Custom | kubectl | Custom |
+| **Kubernetes Required** | No | No | No | **Yes** | No |
+| **Python Required** | No | **Yes** | **Yes** | No | **Yes** |
+| **Language** | Rust | Python | Python | Go | Python |
+| **Single Binary** | Yes | No | No | Yes | No |
+| **MCP Support** | Native | Plugin | No | No | Plugin |
+| **Multi-Provider LLM** | Yes | Yes | Yes | Limited | Yes |
+| **Workflow Orchestration** | Built-in (AgentFlow) | LangGraph | Built-in | Via Argo | No |
+| **Slack/Discord Integration** | Native | Via code | Via code | No | Via code |
+| **PagerDuty/OpsGenie** | Native | Via code | No | No | No |
+| **Jira/GitHub Triggers** | Native | Via code | No | No | Via code |
+| **Target Audience** | DevOps/SRE | Developers | Developers | K8s Admins | Developers |
+| **License** | Apache 2.0 | MIT | MIT | Apache 2.0 | Apache 2.0 |
+
+### Comparison Callouts (4 cards below table)
+
+**Card 1: vs LangChain/CrewAI**
+```
+Title: "No Python Required"
+AOF is YAML-native. Define agents declaratively without writing
+or maintaining Python code. Perfect for teams that live in YAML.
+```
+
+**Card 2: vs Kagent**
+```
+Title: "No Kubernetes Lock-in"
+Kagent requires a K8s cluster. AOF runs anywhere—your laptop,
+VMs, containers, or K8s. No cluster overhead for simple agents.
+```
+
+**Card 3: vs All Python Frameworks**
+```
+Title: "Native Ops Integrations"
+Other frameworks require writing Python code for every integration.
+AOF has Slack, PagerDuty, Jira, Discord, and GitHub built-in.
+Just YAML configuration—no coding required.
+```
+
+**Card 4: vs All**
+```
+Title: "Built for Ops, By Ops"
+Other frameworks target developers building chatbots. AOF is the only
+framework purpose-built for incident response, automation, and operations.
+```
+
+---
+
+## Section 5: Native Ops Integrations
+
+### Layout
+- Full-width section with integration logo grid
+- Trigger types and tool types separated
+
+### Headline
+```
+Connects to Your Entire Ops Stack
+```
+
+### Subheadline
+```
+Native integrations with the tools DevOps teams actually use.
+No plugins. No middleware. Just YAML.
+```
+
+### Trigger Integrations (Event Sources)
+*"Start workflows from any of these:"*
+
+| Integration | Trigger Type | Use Case |
+|-------------|--------------|----------|
+| **Slack** | Messages, slash commands, reactions | "Deploy to prod" commands |
+| **PagerDuty** | Incidents, alerts | Auto-remediation workflows |
+| **GitHub** | PRs, issues, commits, releases | Code review, CI/CD |
+| **Jira** | Ticket created/updated | Sprint automation |
+| **Discord** | Messages, commands | Team notifications |
+| **Webhooks** | Any HTTP POST | Custom integrations |
+| **Cron/Schedule** | Time-based | Daily reports, health checks |
+| **Kafka** | Message streams | Event-driven automation |
+
+### Tool Integrations (Actions)
+*"Take action in any of these:"*
+
+| Integration | Capabilities |
+|-------------|--------------|
+| **Slack** | Send messages, create channels, update threads |
+| **PagerDuty** | Acknowledge, resolve, escalate incidents |
+| **GitHub** | Create PRs, comment, merge, create issues |
+| **Jira** | Create/update tickets, transitions |
+| **Discord** | Send messages, embeds, reactions |
+| **Shell** | kubectl, helm, docker, terraform, ansible |
+| **HTTP** | Any REST API |
+| **MCP Servers** | Extensible tool protocol |
+
+### Integration Code Example
+```yaml
+apiVersion: aof.dev/v1
+kind: AgentFlow
+metadata:
+  name: incident-to-jira
+spec:
+  # Trigger: PagerDuty incident fires
+  trigger:
+    type: PagerDuty
+    config:
+      events: [incident.triggered]
+
+  nodes:
+    # AI diagnoses the issue
+    - id: diagnose
+      type: Agent
+      config:
+        agent: diagnostic-agent
+
+    # Create Jira ticket with diagnosis
+    - id: create-ticket
+      type: Jira
+      config:
+        action: create_issue
+        project: OPS
+        type: Incident
+        summary: "{{incident.title}}"
+        description: "{{diagnose.output}}"
+
+    # Notify team on Slack
+    - id: notify
+      type: Slack
+      config:
+        channel: "#incidents"
+        message: "🚨 {{incident.title}} - Jira: {{create-ticket.url}}"
+
+    # Also post to Discord
+    - id: discord-notify
+      type: Discord
+      config:
+        channel_id: "123456789"
+        embed:
+          title: "Incident: {{incident.title}}"
+          color: 0xFF0000
+```
+
+### Integration Logos Grid
+Display logos in a grid:
+- Slack
+- Discord
+- PagerDuty
+- OpsGenie
+- GitHub
+- GitLab
+- Jira
+- Linear
+- Datadog
+- Prometheus
+- Grafana
+- AWS
+- GCP
+- Azure
+
+---
+
+## Section 6: Use Cases
+
+### Layout
+- 4-column card grid
+- Icons with titles and descriptions
+
+### Headline
+```
+What Can You Build?
+```
+
+### Use Case Cards
+
+**Card 1: Icon - Alert/Bell**
+```
+Title: Incident Response
+Description: Auto-diagnose alerts, suggest fixes, execute
+approved remediations. Integrate with PagerDuty, OpsGenie, Slack.
+```
+
+**Card 2: Icon - Code Review**
+```
+Title: PR Review Bots
+Description: Automated code review for security, performance,
+and best practices. Comments directly on GitHub PRs.
+```
+
+**Card 3: Icon - Chat Bubble**
+```
+Title: Slack/Teams Bots
+Description: On-call assistants that answer questions,
+run commands, and triage issues 24/7.
+```
+
+**Card 4: Icon - Chart/Report**
+```
+Title: Automated Reports
+Description: Daily cluster health checks, cost reports,
+security scans—delivered on schedule.
+```
+
+---
+
+## Section 6: Architecture Overview
+
+### Layout
+- Centered diagram with explanatory text
+
+### Headline
+```
+Simple, Modular Architecture
+```
+
+### Diagram (ASCII art or SVG)
+```
+┌─────────────────────────────────────────────────────────────┐
+│                         aofctl CLI                          │
+│              (kubectl-style user interface)                 │
+└─────────────────────────────────────────────────────────────┘
+                              │
+        ┌─────────────────────┼─────────────────────┐
+        │                     │                     │
+┌───────▼────────┐  ┌────────▼────────┐  ┌────────▼────────┐
+│     Agent      │  │   AgentFleet    │  │   AgentFlow     │
+│  (Single AI)   │  │  (Team of AIs)  │  │  (Workflow DAG) │
+└───────┬────────┘  └────────┬────────┘  └────────┬────────┘
+        │                     │                     │
+        └─────────────────────┼─────────────────────┘
+                              │
+        ┌─────────────────────┼─────────────────────┐
+        │                     │                     │
+┌───────▼────────┐  ┌────────▼────────┐  ┌────────▼────────┐
+│  LLM Providers │  │   MCP Servers   │  │  Integrations   │
+│(OpenAI/Claude/ │  │(kubectl/git/db) │  │(Slack/PagerDuty)│
+│ Gemini/Ollama) │  │                 │  │                 │
+└────────────────┘  └─────────────────┘  └─────────────────┘
+```
+
+### Building Blocks (3 cards below diagram)
+
+**Card 1: Agent**
+```
+Single AI assistant with specific instructions and tools.
+Like a K8s Pod—the smallest deployable unit.
+```
+
+**Card 2: AgentFleet**
+```
+Team of agents working together. Multiple perspectives
+on the same task. Like a K8s Deployment.
+```
+
+**Card 3: AgentFlow**
+```
+Visual workflow DAG for complex automation. Triggers,
+conditions, human approvals. Like n8n or Argo Workflows.
+```
+
+---
+
+## Section 7: Multi-Provider LLM Support
+
+### Layout
+- Logo grid with provider names
+
+### Headline
+```
+Bring Your Own LLM
+```
+
+### Subheadline
+```
+Switch providers with one line. No code changes.
+```
+
+### Provider Grid (logos + names)
+- OpenAI (GPT-4, GPT-4 Turbo)
+- Anthropic (Claude 3.5 Sonnet, Opus)
+- Google (Gemini 2.5 Flash, Pro)
+- Ollama (Llama 3, Mistral, CodeLlama)
+- Groq (Llama 3.1, Mixtral)
+- AWS Bedrock (coming soon)
+
+### Code Example
+```yaml
+# Switch providers instantly
+spec:
+  model: openai:gpt-4           # OpenAI
+  model: anthropic:claude-3-5-sonnet-20241022  # Anthropic
+  model: google:gemini-2.5-flash  # Google
+  model: ollama:llama3          # Local (free!)
+```
+
+---
+
+## Section 8: Code Example - Incident Response
+
+### Layout
+- Full-width code block with syntax highlighting
+- Dark background
+
+### Headline
+```
+Production-Ready in Minutes
+```
+
+### Subheadline
+```
+Complete incident response flow in 30 lines of YAML.
+```
+
+### Code Example
+```yaml
+apiVersion: aof.dev/v1
+kind: AgentFlow
+metadata:
+  name: incident-response
+spec:
+  trigger:
+    type: Webhook
+    config:
+      path: /pagerduty
+
+  nodes:
+    - id: diagnose
+      type: Agent
+      config:
+        agent: diagnostic-agent
+
+    - id: auto-fix
+      type: Agent
+      config:
+        agent: remediation-agent
+      conditions:
+        - severity != "critical"
+
+    - id: human-approval
+      type: Slack
+      config:
+        channel: "#sre-alerts"
+        message: "Critical issue detected. Approve fix?"
+      conditions:
+        - severity == "critical"
+
+  connections:
+    - from: diagnose
+      to: auto-fix
+    - from: diagnose
+      to: human-approval
+```
+
+---
+
+## Section 9: Quick Start
+
+### Layout
+- 3-step numbered guide
+- Terminal examples for each step
+
+### Headline
+```
+Get Started in 5 Minutes
+```
+
+### Step 1
+```
+Title: Install aofctl
+Code: cargo install aofctl
+      # or
+      curl -sSL https://aof.sh/install.sh | bash
+```
+
+### Step 2
+```
+Title: Create an Agent
+Code: cat > agent.yaml <<EOF
+      apiVersion: aof.dev/v1
+      kind: Agent
+      metadata:
+        name: my-assistant
+      spec:
+        model: openai:gpt-4
+        instructions: "You are a helpful DevOps assistant."
+        tools:
+          - shell
+      EOF
+```
+
+### Step 3
+```
+Title: Run It
+Code: export OPENAI_API_KEY=sk-...
+      aofctl run agent agent.yaml
+```
+
+### CTA Button (large, centered, orange-700)
+```
+Read the Full Getting Started Guide →
+```
+Link: https://docs.aof.sh/docs/intro
+
+---
+
+## Section 10: Open Source
+
+### Layout
+- Centered content with GitHub stats
+
+### Headline
+```
+Open Source. Apache 2.0.
+```
+
+### Description
+```
+AOF is fully open source under the Apache 2.0 license.
+Use it commercially, modify it, contribute back.
+```
+
+### GitHub Stats (dynamic badges)
+- Stars count
+- Forks count
+- Contributors count
+- License badge
+
+### CTA
+```
+Star on GitHub →
+```
+Link: https://github.com/agenticdevops/aof
+
+---
+
+## Section 11: Footer CTA
+
+### Layout
+- Full-width dark section
+- Centered large CTA
+
+### Headline
+```
+Ready to Build AI Agents the Ops Way?
+```
+
+### Subheadline
+```
+From zero to production agent in 5 minutes. No Python required.
+```
+
+### Primary CTA Button (large, orange-700)
+```
+Get Started →
+```
+Link: https://docs.aof.sh/docs/intro
+
+### Secondary Links (smaller, below CTA)
+- Documentation: https://docs.aof.sh
+- GitHub: https://github.com/agenticdevops/aof
+- Examples: https://docs.aof.sh/docs/examples
+
+---
+
+## Section 12: Footer
+
+### Layout
+- 4-column footer with links
+- Copyright and social icons
+
+### Column 1: Product
+- Features
+- Documentation
+- Examples
+- Pricing (Free & Open Source)
+
+### Column 2: Resources
+- Getting Started
+- Tutorials
+- API Reference
+- CLI Reference
+
+### Column 3: Community
+- GitHub
+- Discussions
+- Contributing
+- Code of Conduct
+
+### Column 4: Company
+- About
+- Blog (coming soon)
+- Contact
+- Twitter/X
+
+### Bottom Bar
+```
+© 2024 OpsFlow. Apache 2.0 License.
+```
+
+---
+
+## Design System
+
+### Colors
+- **Background**: zinc-950 (#09090b), zinc-900 (#18181b)
+- **Primary Accent**: orange-700 (#c2410c), orange-600 (#ea580c)
+- **Text Primary**: white
+- **Text Secondary**: zinc-400 (#a1a1aa)
+- **Code Background**: zinc-800 (#27272a)
+- **Success**: green-500
+- **Links**: orange-500
+
+### Typography
+- **Headlines**: Inter or system font, bold
+- **Body**: Inter or system font, regular
+- **Code**: JetBrains Mono or Fira Code
+
+### Components
+- **Buttons**: Rounded corners (8px), orange gradient for primary
+- **Code Blocks**: Dark background, syntax highlighting, copy button
+- **Cards**: zinc-900 background, subtle border, hover effect
+- **Icons**: Lucide icons (consistent with docs site)
+
+---
+
+## SEO Metadata
+
+### Title
+```
+AOF - The AI Agent Framework for DevOps | Build Agents with YAML
+```
+
+### Description
+```
+Build AI agents with Kubernetes-style YAML. No Python required.
+The only agent framework built for DevOps, SRE, and Platform Engineers.
+Open source, Apache 2.0.
+```
+
+### Keywords
+```
+AI agents, DevOps automation, SRE tools, Kubernetes YAML,
+LLM framework, incident response, agentic ops, MCP,
+LangChain alternative, CrewAI alternative, Kagent alternative
+```
+
+### Open Graph
+- Title: AOF - AI Agents for DevOps
+- Description: Build AI agents with YAML. No Python required.
+- Image: Social card with terminal preview
+
+---
+
+## Technical Notes for Builder.io
+
+### Animations
+- Hero terminal: Typing animation for YAML and bash commands
+- Feature blocks: Fade-in on scroll
+- Code examples: Syntax highlighting (use Prism.js or Shiki)
+
+### Responsive Breakpoints
+- Desktop: 1280px+
+- Tablet: 768px - 1279px
+- Mobile: < 768px
+
+### Performance
+- Lazy load images below fold
+- Preload hero fonts
+- Minimize JS bundle
+
+### Analytics
+- Track CTA clicks (Get Started, GitHub)
+- Track scroll depth
+- Track time on page
+
+---
+
+## Assets Needed
+
+1. **Logo**: AOF logo in SVG (light and dark versions)
+2. **Social Card**: 1200x630 Open Graph image
+3. **Provider Logos**: OpenAI, Anthropic, Google, Ollama, Groq
+4. **Architecture Diagram**: Clean SVG version
+5. **Favicon**: 32x32 and 16x16 versions
+
+---
+
+## Key Messages to Emphasize
+
+1. **"No Python Required"** - Repeat this often
+2. **"YAML-First"** - Familiar to the target audience
+3. **"kubectl-style"** - Instant recognition
+4. **"Built for Ops, By Ops"** - Only framework with this focus
+5. **"Runs Anywhere"** - No K8s lock-in (vs Kagent)
+6. **"Single Binary"** - No dependency hell
+7. **"Open Source"** - Apache 2.0, use commercially
+8. **"Native Ops Integrations"** - Slack, Discord, PagerDuty, Jira, GitHub out of the box
+9. **"Event-Driven Automation"** - Trigger from any ops tool, act on any ops tool
+
+---
+
+## Competitor Positioning Summary
+
+| Competitor | AOF's Counter-Position |
+|------------|----------------------|
+| **LangChain** | "No Python required. YAML-first for ops teams." |
+| **CrewAI** | "No Python. kubectl-style CLI you already know." |
+| **Kagent** | "No Kubernetes required. Runs anywhere." |
+| **Agno** | "Built for ops automation, not just chatbots." |
+| **All Python frameworks** | "Single Rust binary. Zero dependencies." |
+
+---
+
+*Last Updated: December 2024*


### PR DESCRIPTION
Introduces a comprehensive modular tool system with unified specification:

## ToolSpec Format
- Simple string format: `"shell"` (backward compatible)
- Qualified built-in: `{name: "shell", source: "builtin", config: {...}}`
- Qualified MCP: `{name: "read_file", source: "mcp", server: "filesystem"}`

## New aof-tools Crate
Built-in tools using system CLI wrappers:
- File tools: read_file, write_file, list_directory, search_files
- Shell tool: shell (with security controls)
- Kubectl tools: kubectl_get, kubectl_apply, kubectl_delete, kubectl_logs, etc.
- Docker tools: docker_ps, docker_build, docker_run, docker_logs, etc.
- Git tools: git_status, git_diff, git_log, git_commit, etc.
- Terraform tools: terraform_init, terraform_plan, terraform_apply, etc.
- Observability: prometheus_query, loki_query, elasticsearch_query, etc.
- AWS tools: aws_s3, aws_ec2, aws_logs, aws_iam, aws_lambda, aws_ecs

## Features
- Modular design with feature flags for each tool category
- ToolRegistry for tool registration and discovery
- CompositeToolExecutor combines built-in and MCP executors
- Tool configuration support (timeouts, blocked commands, etc.)
- Comprehensive documentation in docs/tools/index.md

## Example Agents
- devops-agent.yaml: DevOps with K8s, Docker, Git
- sre-agent.yaml: SRE with Prometheus, Loki
- terraform-agent.yaml: Infrastructure as Code
- aws-agent.yaml: AWS cloud operations
- hybrid-agent.yaml: Built-in + MCP tools combined

🤖 Generated with [Claude Code](https://claude.com/claude-code)