### PR TITLE
fix: Graceful MCP server initialization failure handling

### DIFF
--- a/docs/reference/agent-spec.md
+++ b/docs/reference/agent-spec.md
@@ -360,6 +360,34 @@ spec:
 
 For more details, see [MCP Integration Guide](../tools/mcp-integration.md).
 
+### Graceful Degradation
+
+When MCP servers fail to initialize (e.g., unavailable server, network issues, missing packages), the agent will:
+
+1. **Log a warning** with detailed error information
+2. **Continue loading** with any successfully initialized tools
+3. **Fall back to builtin tools** if configured alongside MCP
+
+This ensures agents remain functional even when some external tools are unavailable.
+
+**Example with fallback:**
+```yaml
+spec:
+  tools:
+    # Builtin Shell tool - always available
+    - type: Shell
+      config:
+        allowed_commands: [kubectl, helm]
+
+    # MCP tool - optional, agent continues if unavailable
+    - type: MCP
+      config:
+        name: kubernetes-mcp
+        command: ["npx", "-y", "@example/mcp-server-kubernetes"]
+```
+
+If the MCP server fails to start, the agent will still load with the Shell tool available.
+
 ---
 
 ## Memory Configuration


### PR DESCRIPTION
## Summary

Fixes #87

When MCP servers fail to initialize (e.g., unavailable package, network issues, missing dependencies), the agent now gracefully degrades instead of failing entirely.

## Problem

Previously, if any MCP server failed to initialize, the agent would fail to load with:
```
Error: Failed to load agent

Caused by:
    Tool execution error: No MCP servers could be initialized
```

This was problematic when:
- An MCP server package doesn't exist or is unavailable
- Network issues prevent server initialization
- The user has both builtin tools (Shell) and MCP tools configured

## Solution

The agent now:
1. **Logs a warning** with detailed error information for each failed MCP server
2. **Continues loading** with any successfully initialized tools
3. **Falls back to builtin tools** (Shell, HTTP) if configured alongside MCP

## Changes

- `crates/aof-runtime/src/executor/runtime.rs`:
  - `create_mcp_executor_from_config` now returns `Option<Arc<dyn ToolExecutor>>` instead of error
  - Added `CombinedToolExecutor` to support both builtin and MCP tools
  - Updated `load_agent_from_config` to handle MCP failures gracefully
  - Added test `test_mcp_executor_graceful_failure`

- `docs/reference/agent-spec.md`:
  - Added "Graceful Degradation" section with example

## Testing

Tested with non-existent MCP server - agent loads and responds successfully using Shell tool only.

Log output shows graceful degradation:
```
WARN: Failed to initialize MCP server 'non-existent-mcp': MCP protocol error
WARN: No MCP servers could be initialized. Agent will continue without MCP tools.
INFO: MCP initialization failed, using builtin tools only: ["shell", "kubectl"]
INFO: Agent loaded successfully: test-graceful
```

## Checklist

- [x] Code follows project style
- [x] Tests added for the fix
- [x] Documentation updated
- [x] Manually verified the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
