### PR TITLE
fix: Check YAML kind field before parsing agent configs

### DIFF
--- a/crates/aofctl/src/commands/run.rs
+++ b/crates/aofctl/src/commands/run.rs
@@ -36,11 +36,18 @@ fn parse_agent_config(content: &str, file_path: &str) -> Result<AgentConfig> {
     if let Ok(check) = serde_yaml::from_str::<KindCheck>(content) {
         if let Some(kind) = check.kind {
             if kind != "Agent" {
+                let hint = match kind.as_str() {
+                    "Trigger" => "Triggers are used with 'aofctl serve', not 'aofctl run'".to_string(),
+                    "Fleet" => "Use 'aofctl run fleet <file>' to run a fleet".to_string(),
+                    "Flow" | "AgentFlow" => "Use 'aofctl run flow <file>' to run a flow".to_string(),
+                    "Workflow" => "Use 'aofctl run workflow <file>' to run a workflow".to_string(),
+                    _ => format!("This file contains a {} resource, not an Agent", kind),
+                };
                 return Err(anyhow!(
-                    "Wrong resource type: {}\n\n  Expected: kind: Agent\n  Found: kind: {}\n\n  Hint: Use 'aofctl run {}' instead of 'aofctl run agent'\n",
+                    "Wrong resource type: {}\n\n  Expected: kind: Agent\n  Found: kind: {}\n\n  Hint: {}\n",
                     file_path,
                     kind,
-                    kind.to_lowercase()
+                    hint
                 ));
             }
         }

--- a/crates/aofctl/src/commands/run.rs
+++ b/crates/aofctl/src/commands/run.rs
@@ -27,7 +27,26 @@ struct K8sMetadata {
 
 /// Parse agent config with detailed error messages including field path and line numbers
 fn parse_agent_config(content: &str, file_path: &str) -> Result<AgentConfig> {
-    // First, try the normal parse
+    // First, check if this is the right kind of resource
+    #[derive(serde::Deserialize)]
+    struct KindCheck {
+        kind: Option<String>,
+    }
+
+    if let Ok(check) = serde_yaml::from_str::<KindCheck>(content) {
+        if let Some(kind) = check.kind {
+            if kind != "Agent" {
+                return Err(anyhow!(
+                    "Wrong resource type: {}\n\n  Expected: kind: Agent\n  Found: kind: {}\n\n  Hint: Use 'aofctl run {}' instead of 'aofctl run agent'\n",
+                    file_path,
+                    kind,
+                    kind.to_lowercase()
+                ));
+            }
+        }
+    }
+
+    // Now try the normal parse
     let deserializer = serde_yaml::Deserializer::from_str(content);
     let result: Result<AgentConfig, _> = serde_path_to_error::deserialize(deserializer);
 


### PR DESCRIPTION
## Summary

Fixes #89

When loading agents from a directory, the daemon now checks the `kind` field before attempting to parse files as Agent configs. This prevents confusing errors when the directory contains non-Agent YAML files (Trigger, Fleet, Flow, etc.).

## Problem

Previously, when the agents directory contained a Trigger file (or any non-Agent YAML), the daemon would try to parse it as an Agent and fail with:

```
Error: Failed to parse agent config: pr_review.yaml

  Field: spec
  Error: missing field `model`
```

This was confusing because:
1. The file is a valid Trigger, not an invalid Agent
2. The error message didn't clarify that the file should be in a different directory

## Solution

Added a `yaml_file_has_kind` helper function that checks the `kind` field before attempting full deserialization:

```rust
fn yaml_file_has_kind(path: &Path, expected_kind: &str) -> bool {
    #[derive(Deserialize)]
    struct KindCheck {
        kind: Option<String>,
    }
    // ... parse and check kind
}
```

## Changes

- `crates/aof-core/src/registry.rs`:
  - Added `yaml_file_has_kind` helper function
  - Updated `AgentRegistry.load_directory` to skip non-Agent files

- `crates/aof-triggers/src/handler/mod.rs`:
  - Added `TriggerHandler::yaml_file_has_kind` method
  - Updated `load_agents_from_directory` to check kind before parsing

## Testing

```bash
# Create a directory with mixed YAML files
mkdir /tmp/mixed-agents
cp examples/agents/devops.yaml /tmp/mixed-agents/
cp examples/triggers/slack-starter.yaml /tmp/mixed-agents/pr_review.yaml

# Run daemon - now works without error
aofctl serve --agents-dir /tmp/mixed-agents
# Logs: "Skipping non-Agent file: /tmp/mixed-agents/pr_review.yaml"
# Logs: "Loaded agent 'devops' from /tmp/mixed-agents/devops.yaml"
```

## Checklist

- [x] Code follows project style
- [x] Tests pass
- [x] Documentation N/A (internal behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
