### PR TITLE
fix: aofctl serve now produces visible startup output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `aofctl serve` now produces visible startup output
+  - Changed from tracing (default level: error) to println for critical startup messages
+  - Users can now see server bind address, registered platforms, loaded agents/flows
+  - Error messages use stderr for proper output separation
+
 ## [0.3.1-beta] - 2025-12-26
 
 ### Added

--- a/docs/reference/daemon-config.md
+++ b/docs/reference/daemon-config.md
@@ -421,6 +421,26 @@ aofctl serve \
 aofctl serve --config daemon-config.yaml --port 3000
 ```
 
+### Expected Startup Output
+
+When the server starts successfully, you'll see:
+
+```
+Loading configuration from: daemon-config.yaml
+Starting AOF Trigger Server
+  Bind address: 0.0.0.0:3000
+  Default agent for natural language: devops
+  Registered platform: slack
+  Registered platform: telegram
+Loading AgentFlows from: ./flows/
+  Pre-loaded 19 agents from "./agents/"
+  Loaded 3 AgentFlows: ["k8s-health-check", "docker-troubleshoot", "data-pipeline"]
+Server starting...
+  Health check: http://0.0.0.0:3000/health
+  Webhook endpoint: http://0.0.0.0:3000/webhook/{platform}
+Press Ctrl+C to stop
+```
+
 ---
 
 ## Platform Safety


### PR DESCRIPTION
## Summary
- Fixed `aofctl serve` producing no output on startup
- Changed critical startup messages from tracing macros to println/eprintln
- The CLI's default log level was "error", suppressing all info-level messages

## Changes
- Server bind address, registered platforms, loaded agents/flows now visible
- Error messages use stderr for proper output separation
- Updated docs with expected startup output section

## Test plan
- [x] Built successfully with `cargo build --release`
- [x] Verified startup output: `aofctl serve --config examples/config/daemon.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)