### PR TITLE
fix: GitHub PR reviews now post single response instead of multiple comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Changed from tracing (default level: error) to println for critical startup messages
   - Users can now see server bind address, registered platforms, loaded agents/flows
   - Error messages use stderr for proper output separation
+- GitHub/GitLab/Bitbucket PR reviews now post a single response instead of multiple comments
+  - Intermediate acknowledgment messages ("Thinking...", "Processing...") are skipped for Git platforms
+  - Only the final response is posted, keeping PR threads clean
+  - Slack/Telegram/Discord still show real-time progress indicators
 
 ## [0.3.1-beta] - 2025-12-26
 

--- a/docs/reference/daemon-config.md
+++ b/docs/reference/daemon-config.md
@@ -475,6 +475,32 @@ The server exposes these endpoints for each platform:
 | Telegram | `https://your-domain/webhook/telegram` |
 | Discord | `https://your-domain/webhook/discord` |
 | WhatsApp | `https://your-domain/webhook/whatsapp` |
+| GitHub | `https://your-domain/webhook/github` |
+| GitLab | `https://your-domain/webhook/gitlab` |
+| Bitbucket | `https://your-domain/webhook/bitbucket` |
+
+---
+
+## Git Platform Behavior
+
+GitHub, GitLab, and Bitbucket handle responses differently from chat platforms:
+
+| Aspect | Chat Platforms (Slack/Telegram/Discord) | Git Platforms (GitHub/GitLab/Bitbucket) |
+|--------|----------------------------------------|----------------------------------------|
+| Response style | Real-time updates | Single response only |
+| Progress indicators | "🤔 Thinking...", "🔄 Processing..." shown | Skipped (would create noisy comment threads) |
+| Message updates | Can edit existing messages | Creates new comments |
+| Best for | Interactive conversations | PR reviews, issue triage |
+
+**Why single responses for Git platforms:**
+- Each `send_response` creates a NEW comment in GitHub/GitLab/Bitbucket
+- Progress indicators like "Thinking..." would flood PR threads with multiple comments
+- Only the final response is posted, keeping PR reviews clean and professional
+
+**Example: `/review` on GitHub PR**
+1. User posts `/review` comment on PR
+2. Bot processes (no intermediate comments)
+3. Bot posts ONE comment with the complete review
 
 ---
 


### PR DESCRIPTION
## Summary
- Fixed noisy "Thinking..." and "Processing..." comments in GitHub PR review threads
- Git platforms (GitHub, GitLab, Bitbucket) now only post the final response
- Chat platforms (Slack/Telegram/Discord) continue showing progress indicators

## Problem
When a user posted `/review` on a GitHub PR, multiple intermediate comments were being created:
- "🤔 Thinking..."
- "🔄 Processing..."
- Final response

This flooded PR threads with noise because each `send_response` creates a NEW comment on Git platforms (unlike Slack which can update messages).

## Solution
Added platform check to skip intermediate acknowledgment messages for Git platforms:
```rust
let is_git_platform = matches!(
    platform_impl.platform_name(),
    "github" | "gitlab" | "bitbucket"
);
if !is_git_platform {
    // Send progress indicator only for chat platforms
}
```

## Changes
- `crates/aof-triggers/src/handler/mod.rs` - Skip acks for git platforms in 6 locations
- `docs/reference/daemon-config.md` - Added "Git Platform Behavior" section
- `CHANGELOG.md` - Documented the fix

## Test plan
- [x] Built successfully with `cargo build --release`
- [ ] Manual test: Post `/review` on GitHub PR → should see only ONE response

🤖 Generated with [Claude Code](https://claude.com/claude-code)